### PR TITLE
Make collection-assets "assets" property a Dict

### DIFF
--- a/stac_pydantic/extensions/collection_assets.py
+++ b/stac_pydantic/extensions/collection_assets.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Dict
 
 from pydantic import BaseModel
 
@@ -10,4 +10,4 @@ class CollectionAssetExtension(BaseModel):
     https://github.com/radiantearth/stac-spec/tree/v1.0.0-beta.1/extensions/collection-assets
     """
 
-    assets: List[Asset]
+    assets: Dict[str, Asset]


### PR DESCRIPTION
This is currently a List[Asset], but the spec dictates it's a Dict[str, Asset].