### PR TITLE
Making geometry and bbox optional. 

### DIFF
--- a/stac_pydantic/item.py
+++ b/stac_pydantic/item.py
@@ -2,7 +2,7 @@ from datetime import datetime as dt
 from functools import lru_cache
 from typing import Dict, List, Optional, Tuple, Type, Union
 
-from geojson_pydantic.features import Feature, FeatureCollection
+from geojson_pydantic.features import Feature, FeatureCollection, Geom
 from pydantic import BaseModel, Field, create_model, validator
 from pydantic.datetime_parse import parse_datetime
 from pydantic.fields import FieldInfo
@@ -50,7 +50,8 @@ class Item(Feature):
     properties: ItemProperties
     assets: Dict[str, Asset]
     links: Links
-    bbox: BBox
+    geometry: Optional[Geom]
+    bbox: Optional[BBox]
     stac_extensions: Optional[List[str]]
     collection: Optional[str]
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -328,6 +328,20 @@ def test_geo_interface():
     Item(**test_item)
 
 
+def test_item_null_geometry_bbox():
+    """
+    Tests that a STAC item is valid with
+    no bbox or geometry
+    """
+    test_item = request(EO_EXTENSION)
+
+    # remove geometry and bbox
+    test_item.pop("geometry")
+    test_item.pop("bbox")
+
+    Item(**test_item)
+
+
 def test_api_conformance():
     ConformanceClasses(
         conformsTo=["https://conformance-class-1", "http://conformance-class-2"]


### PR DESCRIPTION
Making `geometry` and `bbox` optional to support optional `geometry`.

I tried adding a validator to check that `bbox` is present when `geometry` is present but it seemed to fail all the tests using the factory.

closes #51