### PR TITLE
landing page conformsTo

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ Unreleased
 ------------------
 - Update to stac version 1.0.0 (#86, @moradology)
 - Remove models for STAC spec extensions (#86, @moradology)
+- Add conformsTo to LandingPage (#90, @moradology)
 
 1.3.9 (2021-03-02)
 ------------------

--- a/stac_pydantic/api/landing.py
+++ b/stac_pydantic/api/landing.py
@@ -16,4 +16,5 @@ class LandingPage(BaseModel):
     title: Optional[str]
     stac_version: str = Field(STAC_VERSION, const=True)
     stac_extensions: Optional[List[AnyUrl]]
+    conformsTo: List[AnyUrl]
     links: Links

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -197,6 +197,10 @@ def test_api_landing_page():
             "https://raw.githubusercontent.com/stac-extensions/eo/v1.0.0/json-schema/schema.json",
             "https://raw.githubusercontent.com/stac-extensions/projection/v1.0.0/json-schema/schema.json",
         ],
+        conformsTo=[
+            "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
+            "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson",
+        ],
         links=[Link(href="http://link", rel="self",)],
     )
 
@@ -208,6 +212,10 @@ def test_api_landing_page_is_catalog():
         stac_extensions=[
             "https://raw.githubusercontent.com/stac-extensions/eo/v1.0.0/json-schema/schema.json",
             "https://raw.githubusercontent.com/stac-extensions/projection/v1.0.0/json-schema/schema.json",
+        ],
+        conformsTo=[
+            "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
+            "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson",
         ],
         links=[Link(href="http://link", rel="self",)],
     )


### PR DESCRIPTION
The `LandingPage` is supposed to advertise its spec conformance via the `conformsTo` field. This PR adds that field as a required list of URLs and is important for addressing https://github.com/stac-utils/stac-fastapi/issues/159