### PR TITLE
Set version to 2.0.0; add release GitHub Workflow

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -46,37 +46,3 @@ jobs:
           flags: unittests
           name: ${{ matrix.platform }}-${{ matrix.tox-env }}
           fail_ci_if_error: false
-
-  # publish:
-  #   needs: [tests]
-  #   runs-on: ubuntu-latest
-  #   if: startsWith(github.event.ref, 'refs/tags') || github.event_name == 'release'
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Set up Python
-  #       uses: actions/setup-python@v1
-  #       with:
-  #         python-version: "3.x"
-
-  #     - name: Install dependencies
-  #       run: |
-  #         python -m pip install --upgrade pip
-  #         python -m pip install tox
-
-  #     - name: Set tag version
-  #       id: tag
-  #       # https://stackoverflow.com/questions/58177786/get-the-current-pushed-tag-in-github-actions
-  #       run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
-
-  #     - name: Set module version
-  #       id: module
-  #       # https://stackoverflow.com/questions/58177786/get-the-current-pushed-tag-in-github-actions
-  #       run: echo ::set-output name=version::$(python setup.py --version)
-
-  #     - name: Build and publish
-  #       if: steps.tag.outputs.tag == steps.module.outputs.version
-  #       env:
-  #         TOXENV: release
-  #         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-  #         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-  #       run: tox

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    if: ${{ github.repository }} == 'stac-utils/stac-pydantic'
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+
+      - name: Install release dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+
+      - name: Build and publish package
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_STACUTILS_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_STACUTILS_PASSWORD }}
+        run: |
+          python setup.py sdist bdist_wheel
+          twine upload dist/*

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,11 +1,26 @@
 Unreleased
 ------------------
+
+2.0.0 (2020-06-29)
+------------------
 - Add Collections model (#81, @moradology)
 - Update to stac version 1.0.0 (#86, @moradology)
 - Remove models for STAC spec extensions (#86, @moradology)
 - Add conformsTo to LandingPage (#90, @moradology)
 
 1.3.9 (2021-03-02)
+------------------
+
+- Add id to landing page, making it a valid catalog (#43, @lossyrob)
+- Make `item_assets` (item assets extension) a dictionary of assets (#47, @kylebarron)
+- Add pre-commit to CI (#48, @kylebarron)
+- Add a `Links` model with custom root type to represent a list of links (#52)
+- Move link related models to their own file (#53)
+- Add link factories for generating inferred links (#55)
+- Switch from relative to absolute imports (#61)
+- Serialize date type fields to `datetime.datetime` upon model creation (#62)
+
+1.3.9 (2020-03-02)
 ------------------
 - Add id to landing page, making it a valid catalog (#43, @lossyrob)
 - Make `item_assets` (item assets extension) a dictionary of assets (#47, @kylebarron)

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
         "Intended Audience :: Developers",
         "Intended Audience :: Information Technology",
         "Intended Audience :: Science/Research",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "License :: OSI Approved :: MIT License",

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     description="Pydantic data models for the STAC spec",
     long_description=desc,
     long_description_content_type="text/markdown",
-    version="1.3.9",
+    version="2.0.0",
     python_requires=">=3.7",
     classifiers=[
         "Intended Audience :: Developers",


### PR DESCRIPTION
This PR updates stac-pydantic to version 2.0.0 in preparation for the upcoming release. It modified the CHANGELOG accordingly, and adds a GitHub Workflow for releases. The action is based on what PySTAC and pystac-client use for their own releases.

Related #91 