### PR TITLE
Add OpenAPI MIME and rel types

### DIFF
--- a/stac_pydantic/links.py
+++ b/stac_pydantic/links.py
@@ -99,3 +99,4 @@ class Relations(str, AutoValueEnum):
     tiles = auto()
     search = auto()
     preview = auto()
+    service_desc = "service-desc"

--- a/stac_pydantic/shared.py
+++ b/stac_pydantic/shared.py
@@ -40,6 +40,7 @@ class MimeTypes(str, Enum):
     json = "application/json"
     html = "text/html"
     text = "text/plain"
+    openapi = "application/vnd.oai.openapi+json;version=3.0"
 
 
 class AssetRoles(str, AutoValueEnum):


### PR DESCRIPTION
Adds `"service-desc"` rel type and `"application/vnd.oai.openapi+json;version=3.0"` MIME type for OpenAPI links in STAC API.