### PR TITLE
Add support for non-ellipsis open date windows

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 Unreleased
 ------------------
+- Allow for non-ellipsis open temporal windows (#103, @moradology)
 
 2.0.1 (2021-07-08)
 ------------------

--- a/stac_pydantic/api/search.py
+++ b/stac_pydantic/api/search.py
@@ -108,10 +108,7 @@ class Search(BaseModel):
 
         dates = []
         for value in values:
-            if value == "..":
-                dates.append(value)
-                continue
-            elif value == "":
+            if value == ".." or value == "":
                 dates.append("..")
                 continue
 

--- a/stac_pydantic/api/search.py
+++ b/stac_pydantic/api/search.py
@@ -50,7 +50,7 @@ class Search(BaseModel):
         values = self.datetime.split("/")
         if len(values) == 1:
             return None
-        if values[0] == "..":
+        if values[0] == ".." or values[0] == "":
             return None
         return parse_datetime(values[0])
 
@@ -59,7 +59,7 @@ class Search(BaseModel):
         values = self.datetime.split("/")
         if len(values) == 1:
             return parse_datetime(values[0])
-        if values[1] == "..":
+        if values[1] == ".." or values[1] == "":
             return None
         return parse_datetime(values[1])
 
@@ -110,6 +110,9 @@ class Search(BaseModel):
         for value in values:
             if value == "..":
                 dates.append(value)
+                continue
+            elif value == "":
+                dates.append("..")
                 continue
 
             parse_datetime(value)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -290,6 +290,10 @@ def test_temporal_search_two_tailed():
     assert search.start_date == utcnow
     assert search.end_date == None
 
+    search = Search(collections=["collection1"], datetime=f"{utcnow_str}/")
+    assert search.start_date == utcnow
+    assert search.end_date == None
+
 
 def test_temporal_search_open():
     # Test open date range


### PR DESCRIPTION
STAC Pydantic currently supports open datetime windows with ellipsis ("DATETIME/.." or "../DATETIME") but [it appears as though](https://github.com/stac-utils/stac-api-validator/blob/afb5a91ed6ce804d6b33fb304d6532dd4c50a227/stac_api_validator/validations.py#L46-L47) it ought to also support datetimes with non-ellipsis open windows too. Such windows have the form "/DATETIME" or "DATETIME/". This PR corrects that oversight.