### PR TITLE
Update for beta.4 changes

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,8 @@
 Unreleased
 ------------------
 
+- Add the canonical and service-doc relation types (#104, @moradology)
+
 2.0.1 (2021-07-08)
 ------------------
 - Add bbox validator to STAC search (#95, @geospatialjeff)

--- a/stac_pydantic/links.py
+++ b/stac_pydantic/links.py
@@ -101,3 +101,4 @@ class Relations(str, AutoValueEnum):
     preview = auto()
     canonical = auto()
     service_desc = "service-desc"
+    service_doc = "service-doc"

--- a/stac_pydantic/links.py
+++ b/stac_pydantic/links.py
@@ -99,4 +99,5 @@ class Relations(str, AutoValueEnum):
     tiles = auto()
     search = auto()
     preview = auto()
+    canonical = auto()
     service_desc = "service-desc"


### PR DESCRIPTION
The only relevant bit of beta.4 for stac-pydantic appears to be the addition of a `canonical` and `service-doc` relation types for links, this PR adds that