### PR TITLE
Make bbox optional in item definition

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 Unreleased
 ------------------
+- Allow item bbox to be null if item geometry is null (#108, @yellowcap)
 
 2.0.2 (2021-11-22)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         "License :: OSI Approved :: MIT License",
     ],
     keywords="stac pydantic validation",
-    author=u"Arturo Engineering",
+    author="Arturo Engineering",
     author_email="engineering@arturo.ai",
     url="https://github.com/stac-utils/stac-pydantic",
     license="MIT",

--- a/stac_pydantic/item.py
+++ b/stac_pydantic/item.py
@@ -46,7 +46,7 @@ class Item(Feature):
     properties: ItemProperties
     assets: Dict[str, Asset]
     links: Links
-    bbox: BBox
+    bbox: Optional[BBox]
     stac_extensions: Optional[List[AnyUrl]]
     collection: Optional[str]
 
@@ -55,6 +55,12 @@ class Item(Feature):
 
     def to_json(self, **kwargs):
         return self.json(by_alias=True, exclude_unset=True, **kwargs)
+
+    @validator("bbox")
+    def validate_bbox(cls, v, values):
+        if v is None and not values.get("geometry"):
+            raise ValueError("bbox is required if geometry is not null")
+        return v
 
 
 class ItemCollection(FeatureCollection):

--- a/tests/example_stac/example-item_geometry-null.json
+++ b/tests/example_stac/example-item_geometry-null.json
@@ -1,0 +1,167 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0",
+    "stac_extensions": [
+      "https://landsat.usgs.gov/stac/landsat-ard-extension/v1.0.0/schema.json",
+      "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+      "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+      "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json",
+      "https://stac-extensions.github.io/storage/v1.0.0/schema.json"
+    ],
+    "id": "LE07_CU_002012_20150101_20210502_02_BA",
+    "geometry": null,
+    "properties": {
+      "description": "Landsat Collection 2 Level-3 Burned Area Product",
+      "datetime": "2015-01-01T18:39:12.4885358Z",
+      "platform": "LANDSAT_7",
+      "instruments": [
+        "ETM"
+      ],
+      "landsat:grid_horizontal": "02",
+      "landsat:grid_vertical": "12",
+      "landsat:grid_region": "CU",
+      "landsat:scene_count": 1,
+      "eo:cloud_cover": 0.0759,
+      "landsat:cloud_shadow_cover": 0.1394,
+      "landsat:snow_ice_cover": 0,
+      "landsat:fill": 95.4286,
+      "proj:epsg": null,
+      "proj:shape": [
+        5000,
+        5000
+      ],
+      "proj:transform": [
+        30,
+        0,
+        -2265585,
+        0,
+        -30,
+        1514805
+      ]
+    },
+    "assets": {
+      "index": {
+        "title": "HTML index page",
+        "type": "text/html",
+        "roles": [
+          "metadata"
+        ],
+        "href": "https://landsatlook.usgs.gov/stac-browser/collection02/BA/2015/CU/002/012/LE07_CU_002012_20150101_20210502_02_BA/LE07_CU_002012_20150101_20210502_02"
+      },
+      "bp": {
+        "title": "Burn Probability",
+        "description": "Collection 2 Level-3 Albers Burn Probability Burned Area",
+        "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+        "roles": [
+          "data"
+        ],
+        "href": "https://landsatlook.usgs.gov/level-3/collection02/BA/2015/CU/002/012/LE07_CU_002012_20150101_20210502_02_BA/LE07_CU_002012_20150101_20210502_02_BP.TIF",
+        "alternate": {
+          "s3": {
+            "storage:platform": "AWS",
+            "storage:requester_pays": true,
+            "href": "s3://usgs-landsat-level-3/collection02/BA/2015/CU/002/012/LE07_CU_002012_20150101_20210502_02_BA/LE07_CU_002012_20150101_20210502_02_BP.TIF"
+          }
+        }
+      },
+      "bc": {
+        "title": "Burn Classification",
+        "description": "Collection 2 Level-3 Albers Burn Classification Burned Area",
+        "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+        "roles": [
+          "data"
+        ],
+        "href": "https://landsatlook.usgs.gov/level-3/collection02/BA/2015/CU/002/012/LE07_CU_002012_20150101_20210502_02_BA/LE07_CU_002012_20150101_20210502_02_BC.TIF",
+        "alternate": {
+          "s3": {
+            "storage:platform": "AWS",
+            "storage:requester_pays": true,
+            "href": "s3://usgs-landsat-level-3/collection02/BA/2015/CU/002/012/LE07_CU_002012_20150101_20210502_02_BA/LE07_CU_002012_20150101_20210502_02_BC.TIF"
+          }
+        }
+      },
+      "quick_look": {
+        "title": "Quick Look File",
+        "description": "Collection 2 Level-3 Albers Quick Look File Burned Area",
+        "type": "image/png",
+        "roles": [
+          "data"
+        ],
+        "href": "https://landsatlook.usgs.gov/level-3/collection02/BA/2015/CU/002/012/LE07_CU_002012_20150101_20210502_02_BA/LE07_CU_002012_20150101_20210502_02_QuickLook.png",
+        "alternate": {
+          "s3": {
+            "storage:platform": "AWS",
+            "storage:requester_pays": true,
+            "href": "s3://usgs-landsat-level-3/collection02/BA/2015/CU/002/012/LE07_CU_002012_20150101_20210502_02_BA/LE07_CU_002012_20150101_20210502_02_QuickLook.png"
+          }
+        }
+      },
+      "xml": {
+        "title": "Extensible Metadata File",
+        "description": "Collection 2 Level-3 Albers Extensible Metadata File Burned Area",
+        "type": "application/xml",
+        "roles": [
+          "metadata"
+        ],
+        "href": "https://landsatlook.usgs.gov/level-3/collection02/BA/2015/CU/002/012/LE07_CU_002012_20150101_20210502_02_BA/LE07_CU_002012_20150101_20210502_02.xml",
+        "alternate": {
+          "s3": {
+            "storage:platform": "AWS",
+            "storage:requester_pays": true,
+            "href": "s3://usgs-landsat-level-3/collection02/BA/2015/CU/002/012/LE07_CU_002012_20150101_20210502_02_BA/LE07_CU_002012_20150101_20210502_02.xml"
+          }
+        }
+      },
+      "json": {
+        "title": "Extensible Metadata File (json)",
+        "description": "Collection 2 Level-3 Albers Extensible Metadata File (json) Burned Area",
+        "type": "application/json",
+        "roles": [
+          "metadata"
+        ],
+        "href": "https://landsatlook.usgs.gov/level-3/collection02/BA/2015/CU/002/012/LE07_CU_002012_20150101_20210502_02_BA/LE07_CU_002012_20150101_20210502_02.json",
+        "alternate": {
+          "s3": {
+            "storage:platform": "AWS",
+            "storage:requester_pays": true,
+            "href": "s3://usgs-landsat-level-3/collection02/BA/2015/CU/002/012/LE07_CU_002012_20150101_20210502_02_BA/LE07_CU_002012_20150101_20210502_02.json"
+          }
+        }
+      }
+    },
+    "links": [
+      {
+        "rel": "self",
+        "href": "https://landsatlook.usgs.gov/stac-server/collections/landsat-c2l3-ba/items/LE07_CU_002012_20150101_20210502_02_BA"
+      },
+      {
+        "rel": "derived_from",
+        "href": "https://landsatlook.usgs.gov/stac-server/collections/landsat-c2ard-sr/items/LE07_CU_002012_20150101_20210502_02_SR"
+      },
+      {
+        "rel": "derived_from",
+        "href": "https://landsatlook.usgs.gov/stac-server/collections/landsat-c2ard-st/items/LE07_CU_002012_20150101_20210502_02_ST"
+      },
+      {
+        "rel": "derived_from",
+        "href": "https://landsatlook.usgs.gov/stac-server/collections/landsat-c2ard-ta/items/LE07_CU_002012_20150101_20210502_02_TOA"
+      },
+      {
+        "rel": "derived_from",
+        "href": "https://landsatlook.usgs.gov/stac-server/collections/landsat-c2ard-bt/items/LE07_CU_002012_20150101_20210502_02_BT"
+      },
+      {
+        "rel": "parent",
+        "href": "https://landsatlook.usgs.gov/stac-server/collections/landsat-c2l3-ba"
+      },
+      {
+        "rel": "collection",
+        "href": "https://landsatlook.usgs.gov/stac-server/collections/landsat-c2l3-ba"
+      },
+      {
+        "rel": "root",
+        "href": "https://landsatlook.usgs.gov/stac-server/"
+      }
+    ],
+    "collection": "landsat-c2l3-ba"
+  }

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -38,6 +38,7 @@ VERSION_EXTENSION_COLLECTION = "example-collection_version-extension.json"
 VIEW_EXTENSION = "example-landsat8_view-extension.json"
 DATETIME_RANGE = "datetimerange.json"
 EXAMPLE_COLLECTION_LIST = "example-collection-list.json"
+ITEM_GEOMETRY_NULL = "example-item_geometry-null.json"
 
 
 @pytest.mark.parametrize(
@@ -544,3 +545,18 @@ def test_collection_list():
     test_collection_list = request(EXAMPLE_COLLECTION_LIST)
     valid_collection_list = Collections(**test_collection_list).to_dict()
     dict_match(test_collection_list, valid_collection_list)
+
+
+def test_geometry_null_item():
+    test_item = request(ITEM_GEOMETRY_NULL)
+    valid_item = Item(**test_item).to_dict()
+    dict_match(test_item, valid_item)
+
+
+def test_item_bbox_validation():
+    test_item = request(LABEL_EXTENSION)
+    test_item["bbox"] = None
+    with pytest.raises(
+        ValueError, match="bbox is required if geometry is not null"
+    ) as e:
+        Item(**test_item)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -203,7 +203,12 @@ def test_api_landing_page():
             "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
             "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson",
         ],
-        links=[Link(href="http://link", rel="self",)],
+        links=[
+            Link(
+                href="http://link",
+                rel="self",
+            )
+        ],
     )
 
 
@@ -219,7 +224,12 @@ def test_api_landing_page_is_catalog():
             "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
             "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson",
         ],
-        links=[Link(href="http://link", rel="self",)],
+        links=[
+            Link(
+                href="http://link",
+                rel="self",
+            )
+        ],
     )
     catalog = Catalog(**landing_page.dict())
 


### PR DESCRIPTION
This solution proposes to make the bbox field in the item model optional. In the stac-item spec, the bbox field is nullable, if the Geometry field is null.

Refs: https://github.com/stac-utils/stac-fastapi/issues/350

Fixes https://github.com/stac-utils/stac-pydantic/issues/107, https://github.com/stac-utils/stac-pydantic/issues/51