### PR TITLE
Update Extension docs for stac-pydantic 2.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,123 +53,36 @@ assert catalog.links[0].href == "item.json"
 ```
 
 ### Extensions
-STAC defines many extensions which let the user customize the data in their catalog.  Extensions can be validated
-implicitly or explicitly:
-
-#### Implicit
-The `item_model_factory` function creates an appropriate Pydantic model based on the structure of the item by looking
-at the extensions defined by the `stac_extensions` member.  The model can be created once and reused for the life of
-the interpreter.
+STAC defines many extensions which let the user customize the data in their catalog. `stac-pydantic.extensions.validate_extensions` will validate a `dict`, `Item`, `Collection` or `Catalog` against the schema urls provided in the `stac_extensions` property: 
 
 ```python
-from stac_pydantic import item_model_factory
+from stac_pydantic import Item
+from stac_pydantic.extensions import validate_extensions
 
 stac_item = {
+    "id": "12345",
     "type": "Feature",
     "stac_extensions": [
-        "eo"
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json" 
     ],
-    "geometry": ...,
+    "geometry": { "type": "Point", "coordinates": [0, 0] },
     "properties": {
         "datetime": "2020-03-09T14:53:23.262208+00:00",
-        "eo:gsd": 0.15,
-        "eo:cloud_cover": 17
+        "eo:cloud_cover": 25,
     },
-    "links": ...,
-    "assets": ...,
+    "links": [],
+    "assets": [],
 }
 
-model = item_model_factory(stac_item)
-item = model(**stac_item)
-
->>> pydantic.error_wrappers.ValidationError: 1 validation error for Item
-    __root__ -> properties -> eo:bands
-        field required (eo) (type=value_error.missing)
+model = Item(**stac_item) 
+validate_extensions(model, reraise_exception=True)
+assert getattr(model.properties, "eo:cloud_cover") == 25 
 ```
 
-The `stac_pydantic.validate_item` function provides a convenience wrapper over `item_model_factory` for one-off validation:
-
-```python
-from stac_pydantic import validate_item
-
-assert validate_item(stac_item)
-```
-
-#### Explicit
-Subclass any of the models provided by the library to declare a customized validator:
-
-```python
-from stac_pydantic import Item, ItemProperties, Extensions
-
-class CustomProperties(Extensions.view, ItemProperties):
-    ...
-
-class CustomItem(Item):
-    properties: CustomProperties # Override properties model
-
-stac_item = {
-    "type": "Feature",
-    "geometry": ...,
-    "properties": {
-        "datetime": "2020-03-09T14:53:23.262208+00:00",
-        "view:off_nadir": 3.78,
-    },
-    "links": ...,
-    "assets": ...,
-}
-
-item = CustomItem(**stac_item)
-assert item.properties.off_nadir == 3.78
-```
+The complete list of current STAC Extensions can be found [here](https://stac-extensions.github.io/).
 
 #### Vendor Extensions
-STAC allows 3rd parties to define their own extensions for specific implementations which aren't currently covered by
-the available content extensions.  You can validate vendor extensions in a similar fashion:
-```python
-from pydantic import BaseModel
-from stac_pydantic import Extensions, Item
-
-# 1. Create a model for the extension
-class LandsatExtension(BaseModel):
-    row: int
-    column: int
-    
-    # Setup extension namespace in model config
-    class Config:
-        allow_population_by_fieldname = True
-        alias_generator = lambda field_name: f"landsat:{field_name}"
-
-# 2. Register the extension
-Extensions.register("landsat", LandsatExtension)
-
-# 3. Use model as normal
-stac_item = {
-    "type": "Feature",
-    "stac_extensions": [
-        "landsat",
-        "view"
-],
-    "geometry": ...,
-    "properties": {
-        "datetime": "2020-03-09T14:53:23.262208+00:00",
-        "view:off_nadir": 3.78,
-        "landsat:row": 230,
-        "landsat:column": 178 
-    },
-    "links": ...,
-    "assets": ...,
-}
-
-item = Item(**stac_item)
-assert item.properties.row == 230
-assert item.properties.column == 178
-```
-Vendor extensions are often defined in `stac_extensions` as a [remote reference](https://github.com/radiantearth/stac-spec/blob/v0.9.0/item-spec/examples/landsat8-sample.json#L6) to a JSON schema.  When registering extensions, you may use the `alias` kwarg to 
-indicate that the model represents a specific remote reference:
-
-```python
-Extensions.register("landsat", LandsatExtension, alias="https://example.com/stac/landsat-extension/1.0/schema.json")
-```
+The same procedure described above works for any STAC Extension schema as long as it can be loaded from a public url.
 
 ### Exporting Models
 Most STAC extensions are namespaced with a colon (ex `eo:gsd`) to keep them distinct from other extensions.  Because


### PR DESCRIPTION
I was digging into the extension features of stac-pydantic and noticed that the docs in the README for this feature are out of date.

This MR updates the README to be compliant with stac-pydantic 2.0+

I'm not particularly familiar with this feature, I just wrote this based on a bit of playing around in an ipython shell and browsing the docs. Feel free to update as desired.