### PR TITLE
Add 'children' link relation

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,7 @@
 Unreleased
 ------------------
 - Allow item bbox to be null if item geometry is null (#108, @yellowcap)
+- Include 'children' link relation (#112, @moradology)
 
 2.0.2 (2021-11-22)
 ------------------

--- a/stac_pydantic/links.py
+++ b/stac_pydantic/links.py
@@ -87,6 +87,7 @@ class Relations(str, AutoValueEnum):
     root = auto()
     parent = auto()
     child = auto()
+    children = auto()
     item = auto()
     license = auto()
     derived_from = auto()


### PR DESCRIPTION
In STAC 1beta5, a `children` link relation was added. This PR incorporates that into stac-pydantic.