### PR TITLE
Permit None value for datetime

### DIFF
--- a/stac_pydantic/item.py
+++ b/stac_pydantic/item.py
@@ -16,11 +16,11 @@ class ItemProperties(StacCommonMetadata):
     https://github.com/radiantearth/stac-spec/blob/v1.0.0/item-spec/item-spec.md#properties-object
     """
 
-    datetime: Union[dt, str] = Field(..., alias="datetime")
+    datetime: Union[dt, str, None] = Field(..., alias="datetime")
 
     @validator("datetime")
-    def validate_datetime(cls, v: Union[dt, str], values: Dict[str, Any]) -> dt:
-        if v == "null":
+    def validate_datetime(cls, v: Union[dt, str, None], values: Dict[str, Any]) -> dt:
+        if v in ("null", None):
             if not values["start_datetime"] and not values["end_datetime"]:
                 raise ValueError(
                     "start_datetime and end_datetime must be specified when datetime is null"

--- a/stac_pydantic/item.py
+++ b/stac_pydantic/item.py
@@ -16,18 +16,15 @@ class ItemProperties(StacCommonMetadata):
     https://github.com/radiantearth/stac-spec/blob/v1.0.0/item-spec/item-spec.md#properties-object
     """
 
-    datetime: Union[dt, str, None] = Field(..., alias="datetime")
+    datetime: Optional[dt] = Field(..., alias="datetime")
 
     @validator("datetime")
-    def validate_datetime(cls, v: Union[dt, str, None], values: Dict[str, Any]) -> dt:
-        if v in ("null", None):
+    def validate_datetime(cls, v: Optional[dt], values: Dict[str, Any]) -> Optional[dt]:
+        if v is None:
             if not values["start_datetime"] and not values["end_datetime"]:
                 raise ValueError(
                     "start_datetime and end_datetime must be specified when datetime is null"
                 )
-
-        if isinstance(v, str):
-            return parse_datetime(v)
 
         return v
 

--- a/stac_pydantic/item.py
+++ b/stac_pydantic/item.py
@@ -21,7 +21,7 @@ class ItemProperties(StacCommonMetadata):
     @validator("datetime")
     def validate_datetime(cls, v: Optional[dt], values: Dict[str, Any]) -> Optional[dt]:
         if v is None:
-            if not values["start_datetime"] and not values["end_datetime"]:
+            if not all([values.get("start_datetime"), values.get("end_datetime")]):
                 raise ValueError(
                     "start_datetime and end_datetime must be specified when datetime is null"
                 )

--- a/stac_pydantic/item.py
+++ b/stac_pydantic/item.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, List, Optional, Union
 
 from geojson_pydantic.features import Feature, FeatureCollection  # type: ignore
 from pydantic import AnyUrl, Field, root_validator, validator
-from pydantic.datetime_parse import parse_datetime
 
 from stac_pydantic.api.extensions.context import ContextExtension
 from stac_pydantic.links import Links


### PR DESCRIPTION
As mentioned in #77, we should permit a None value for datetime property under certain circumstances.

By the time we are running our validators, we are validating against a Python dictionary (ie not a JSON string).  For this reason, we should be permitting `None` values for `properties.datetime` when `properties.start_datetime` and `properties.end_datetime` are provided.

Going a bit further, I'm not sure that it's correct for us to permit `properties.datetime` to ever equal `"null"` (as is currently supported).  The [STAC Spec](https://github.com/radiantearth/stac-spec/blob/789e90fba4c7119bc925d26f75f47bacf44c91e6/item-spec/item-spec.md?plain=1#L141) states that `null` is sometimes permitted, however `"null"` is never mentioned as being permitted.

---

closes #77

Before:
```sh
$ git checkout master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
$ stac-pydantic validate-item https://raw.githubusercontent.com/radiantearth/stac-spec/master/examples/collectionless-item.json

1 validation error for Item
properties -> datetime
  none is not an allowed value (type=type_error.none.not_allowed)
```
After:
```sh
$ git checkout patch-1
Switched to branch 'patch-1'
Your branch is up to date with 'origin/patch-1'.
$ stac-pydantic validate-item https://raw.githubusercontent.com/radiantearth/stac-spec/master/examples/collectionless-item.json

https://raw.githubusercontent.com/radiantearth/stac-spec/master/examples/collectionless-item.json is valid
```