### PR TITLE
Fix blank alias in Catalog model

### DIFF
--- a/stac_pydantic/catalog.py
+++ b/stac_pydantic/catalog.py
@@ -11,7 +11,7 @@ class Catalog(BaseModel):
     https://github.com/radiantearth/stac-spec/blob/v1.0.0/catalog-spec/catalog-spec.md
     """
 
-    id: str = Field(..., alias="", min_length=1)
+    id: str = Field(..., alias="id", min_length=1)
     description: str = Field(..., alias="description", min_length=1)
     stac_version: str = Field(STAC_VERSION, const=True, min_length=1)
     links: Links


### PR DESCRIPTION
The current model seems to work alright with various FastAPI implementations, but I've been running into errors instantiating models in other contexts. The error message I've been getting is something like this:

```
pydantic.error_wrappers.ValidationError: 1 validation error for Collection

  field required (type=value_error.missing)
```

I believe the blank field alias is the culprit here, as it prevents an "id" from being assigned on model instantiation (unless instantiating from a dict with an empty string as a key).