### PR TITLE
pin geojson-pydantic and pydantic to avoid breaking changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     license="MIT",
     packages=find_packages(exclude=["tests"]),
     zip_safe=False,
-    install_requires=["click", "pydantic>=1.6", "geojson-pydantic"],
+    install_requires=["click", "pydantic>=1.6,<2.0", "geojson-pydantic>=0.4,<1.0"],
     tests_require=extras["dev"],
     setup_requires=["pytest-runner"],
     entry_points={"console_scripts": ["stac-pydantic=stac_pydantic.scripts.cli:app"]},


### PR DESCRIPTION
ref #124 

Latest version of Pydantic and geojson-pydantic have breaking changes, it's better to pin the libraries! 