### PR TITLE
refactor datetime parsing and validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ keywords=["stac", "pydantic", "validation"]
 authors=[{ name = "Arturo Engineering", email = "engineering@arturo.ai"}]
 license= { text = "MIT" }
 requires-python=">=3.8"
-dependencies = ["click>=8.1.7", "pydantic>=2.4.1", "geojson-pydantic>=1.0.0"]
+dependencies = ["click>=8.1.7", "pydantic>=2.4.1", "geojson-pydantic>=1.0.0", "ciso8601~=2.3"]
 dynamic = ["version", "readme"]
 
 [project.scripts]

--- a/stac_pydantic/item.py
+++ b/stac_pydantic/item.py
@@ -1,6 +1,7 @@
 from datetime import datetime as dt
 from typing import Any, Dict, List, Optional, Union
 
+from ciso8601 import parse_rfc3339
 from geojson_pydantic import Feature
 from pydantic import (
     AnyUrl,
@@ -19,7 +20,6 @@ from stac_pydantic.shared import (
     StacBaseModel,
     StacCommonMetadata,
 )
-from stac_pydantic.utils import parse_datetime
 from stac_pydantic.version import STAC_VERSION
 
 
@@ -47,13 +47,13 @@ class ItemProperties(StacCommonMetadata):
                 )
 
         if isinstance(datetime, str):
-            data["datetime"] = parse_datetime(datetime)
+            data["datetime"] = parse_rfc3339(datetime)
 
         if isinstance(start_datetime, str):
-            data["start_datetime"] = parse_datetime(start_datetime)
+            data["start_datetime"] = parse_rfc3339(start_datetime)
 
         if isinstance(end_datetime, str):
-            data["end_datetime"] = parse_datetime(end_datetime)
+            data["end_datetime"] = parse_rfc3339(end_datetime)
 
         return data
 

--- a/stac_pydantic/utils.py
+++ b/stac_pydantic/utils.py
@@ -1,9 +1,5 @@
-import json
-from datetime import datetime
 from enum import Enum
-from typing import Any, Callable, List
-
-from pydantic import TypeAdapter
+from typing import Any, List
 
 
 class AutoValueEnum(Enum):
@@ -11,8 +7,3 @@ class AutoValueEnum(Enum):
         name: str, start: int, count: int, last_values: List[Any]
     ) -> Any:
         return name
-
-
-parse_datetime: Callable[[Any], datetime] = lambda x: TypeAdapter(
-    datetime
-).validate_json(json.dumps(x))

--- a/tests/api/test_search.py
+++ b/tests/api/test_search.py
@@ -1,5 +1,5 @@
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 
 import pytest
 from pydantic import ValidationError
@@ -92,6 +92,12 @@ def test_invalid_temporal_search():
     utcnow = datetime.utcnow().strftime("%Y-%m-%d")
     with pytest.raises(ValidationError):
         Search(collections=["collection1"], datetime=utcnow)
+
+    t1 = datetime.utcnow()
+    t2 = t1 + timedelta(seconds=100)
+    t3 = t2 + timedelta(seconds=100)
+    with pytest.raises(ValidationError):
+        Search(collections=["collection1"], datetime=f"{t1.strftime(DATETIME_RFC339)}/{t2.strftime(DATETIME_RFC339)}/{t3.strftime(DATETIME_RFC339)}",)
 
     # End date is before start date
     start = datetime.utcnow()


### PR DESCRIPTION
ref https://github.com/stac-utils/stac-pydantic/pull/132#issuecomment-1927419150

A while ago stac-fastapi moved to `ciso8601` and then to `pyiso8601` (https://github.com/stac-utils/stac-fastapi/pull/448) but I think now it's safe to use `ciso8601` for datetime parsing and validation (at least if using ~=2.3, https://github.com/developmentseed/tipg/issues/39#issuecomment-1472730201) 