### PR TITLE
Improve Item validation rules and add support for py3.12

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
@@ -27,11 +27,14 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install tox pre-commit
+          python -m pip install '.[lint]'
           pre-commit install
 
+      - name: Lint
+        run: pre-commit run --all
+
       # Run tox using the version of Python in `PATH`
-      - name: Run Tox
+      - name: Test
         run: tox -e py
 
       - name: Upload Results

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@
 - Fix validator for Item `datetime` and Common MetaData `start_datetime` and `end_datetime`
 - Make sure all `datetime` fields are correctly parsed
 - Include `datetime` and `license` to Common MetaData
+- Be more permissive about date format
 - Make sure default values for required but unset fields are correctly parsed
 - Add support from Python 3.12
 - Lint all files

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,13 @@
+- Require `type` property to be set for Catalog and Collections
+- Fix validator for Item `datetime` and Common MetaData `start_datetime` and `end_datetime`
+- Make sure all `datetime` fields are correctly parsed
+- Include `datetime` and `license` to Common MetaData
+- Make sure default values for required but unset fields are correctly parsed
+- Add support from Python 3.12
+- Lint all files
+- Increase test coverage
+
+
 3.0.0 (2024-01-25)
 ------------------
 - Support pydantic>2.0 (@huard)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ lint = ["types-requests>=2.31.0.5",
         "isort>=5.12.0",
         "flake8>=6.1.0",
         "Flake8-pyproject>=1.2.3",
-        "mypy>=1.5.1",
+        "mypy>=1.8.0",
         "pre-commit>=3.4.0",
         "tox>=4.11.3"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ lint = ["types-requests>=2.31.0.5",
         "isort>=5.12.0",
         "flake8>=6.1.0",
         "Flake8-pyproject>=1.2.3",
-        "mypy>=1.8.0",
+        "mypy==1.4.1",
         "pre-commit>=3.4.0",
         "tox>=4.11.3"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
         "pydantic>=2.4.1",
         "geojson-pydantic>=1.0.0",
         "ciso8601~=2.3",
-        "python-dateutil>=2.7.0"]
+        "python-dateutil>=2.7.0",]
 dynamic = ["version", "readme"]
 
 [project.scripts]
@@ -49,6 +49,7 @@ lint = [
         "types-requests>=2.31.0.5",
         "types-jsonschema>=4.19.0.3",
         "types-PyYAML>=6.0.12.12",
+        "types-python-dateutil>=2.7.0",
         "black>=23.9.1",
         "isort>=5.12.0",
         "flake8>=6.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name="stac-pydantic"
-description="Pydantic data models for the STAC spec"
-classifiers=[
+name = "stac-pydantic"
+description = "Pydantic data models for the STAC spec"
+classifiers = [
         "Intended Audience :: Developers",
         "Intended Audience :: Information Technology",
         "Intended Audience :: Science/Research",
@@ -13,13 +13,17 @@ classifiers=[
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
-        "License :: OSI Approved :: MIT License",
-    ]
-keywords=["stac", "pydantic", "validation"]
-authors=[{ name = "Arturo Engineering", email = "engineering@arturo.ai"}]
-license= { text = "MIT" }
-requires-python=">=3.8"
-dependencies = ["click>=8.1.7", "pydantic>=2.4.1", "geojson-pydantic>=1.0.0", "ciso8601~=2.3"]
+        "Programming Language :: Python :: 3.12",
+        "License :: OSI Approved :: MIT License"]
+keywords = ["stac", "pydantic", "validation"]
+authors = [{ name = "Arturo Engineering", email = "engineering@arturo.ai" }]
+license = { text = "MIT" }
+requires-python = ">=3.8"
+dependencies = [
+        "click>=8.1.7",
+        "pydantic>=2.4.1",
+        "geojson-pydantic>=1.0.0",
+        "ciso8601~=2.3"]
 dynamic = ["version", "readme"]
 
 [project.scripts]
@@ -27,10 +31,11 @@ stac-pydantic = "stac_pydantic.scripts.cli:app"
 
 [project.urls]
 homepage = "https://github.com/stac-utils/stac-pydantic"
-repository ="https://github.com/stac-utils/stac-pydantic.git"
+repository = "https://github.com/stac-utils/stac-pydantic.git"
 
 [project.optional-dependencies]
-dev = ["arrow>=1.2.3",
+dev = [
+        "arrow>=1.2.3",
         "pytest>=7.4.2",
         "pytest-cov>=4.1.0",
         "pytest-icdiff>=0.8",
@@ -39,7 +44,8 @@ dev = ["arrow>=1.2.3",
         "dictdiffer>=0.9.0",
         "jsonschema>=4.19.1",
         "pyyaml>=6.0.1"]
-lint = ["types-requests>=2.31.0.5",
+lint = [
+        "types-requests>=2.31.0.5",
         "types-jsonschema>=4.19.0.3",
         "types-PyYAML>=6.0.12.12",
         "black>=23.9.1",
@@ -52,10 +58,10 @@ lint = ["types-requests>=2.31.0.5",
 
 [tool.setuptools.dynamic]
 version = { attr = "stac_pydantic.version.__version__" }
-readme = {file = ["README.md"], content-type = "text/markdown"}
+readme = { file = ["README.md"], content-type = "text/markdown" }
 
 [tool.setuptools.package-data]
-stac_pydantic= ["*.typed"]
+stac_pydantic = ["*.typed"]
 
 [tool.setuptools.packages.find]
 include = ["stac_pydantic*"]
@@ -81,6 +87,6 @@ exclude = ["tests", ".venv"]
 
 [tool.flake8]
 ignore = ["E203", "E501"]
-select = ["C","E","F","W","B","B950"]
+select = ["C", "E", "F", "W", "B", "B950"]
 exclude = ["tests", ".venv"]
 max-line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ dependencies = [
         "click>=8.1.7",
         "pydantic>=2.4.1",
         "geojson-pydantic>=1.0.0",
-        "ciso8601~=2.3"]
+        "ciso8601~=2.3",
+        "python-dateutil>=2.7.0"]
 dynamic = ["version", "readme"]
 
 [project.scripts]

--- a/stac_pydantic/api/search.py
+++ b/stac_pydantic/api/search.py
@@ -117,7 +117,9 @@ class Search(BaseModel):
             dates.append(parse_rfc3339(value))
 
         if len(values) > 2:
-            raise ValueError("Invalid datetime range, must match format (begin_date, end_date)")
+            raise ValueError(
+                "Invalid datetime range, must match format (begin_date, end_date)"
+            )
 
         if not {"..", ""}.intersection(set(values)):
             if dates[0] > dates[1]:

--- a/stac_pydantic/catalog.py
+++ b/stac_pydantic/catalog.py
@@ -1,6 +1,6 @@
-from typing import List, Literal, Optional
+from typing import Any, List, Literal, Optional
 
-from pydantic import AnyUrl, ConfigDict, Field
+from pydantic import AnyUrl, ConfigDict, Field, model_validator
 
 from stac_pydantic.links import Links
 from stac_pydantic.shared import SEMVER_REGEX, StacBaseModel
@@ -14,13 +14,23 @@ class _Catalog(StacBaseModel):
 
     id: str = Field(..., alias="id", min_length=1)
     description: str = Field(..., alias="description", min_length=1)
-    stac_version: str = Field(STAC_VERSION, pattern=SEMVER_REGEX)
-    links: Links = Links(root=[])
-    stac_extensions: Optional[List[AnyUrl]] = []
+    stac_version: str = Field(..., pattern=SEMVER_REGEX)
+    links: Links
+    stac_extensions: Optional[List[AnyUrl]] = None
     title: Optional[str] = None
     type: str
     model_config = ConfigDict(use_enum_values=True, extra="allow")
 
+    @model_validator(mode="before")
+    @classmethod
+    def set_default_links(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            if data.get("links") is None:
+                data["links"] = []
+            if data.get("stac_version") is None:
+                data["stac_version"] = STAC_VERSION
+        return data
+
 
 class Catalog(_Catalog):
-    type: Literal["Catalog"] = "Catalog"
+    type: Literal["Catalog"]

--- a/stac_pydantic/catalog.py
+++ b/stac_pydantic/catalog.py
@@ -15,7 +15,7 @@ class _Catalog(StacBaseModel):
     id: str = Field(..., alias="id", min_length=1)
     description: str = Field(..., alias="description", min_length=1)
     stac_version: str = Field(STAC_VERSION, pattern=SEMVER_REGEX)
-    links: Links
+    links: Links = Links(root=[])
     stac_extensions: Optional[List[AnyUrl]] = []
     title: Optional[str] = None
     type: str

--- a/stac_pydantic/collection.py
+++ b/stac_pydantic/collection.py
@@ -52,4 +52,4 @@ class Collection(_Catalog):
     keywords: Optional[List[str]] = None
     providers: Optional[List[Provider]] = None
     summaries: Optional[Dict[str, Union[Range, List[Any], Dict[str, Any]]]] = None
-    type: Literal["Collection"] = "Collection"
+    type: Literal["Collection"]

--- a/stac_pydantic/item.py
+++ b/stac_pydantic/item.py
@@ -1,25 +1,11 @@
-from datetime import datetime as dt
 from typing import Any, Dict, List, Optional
 
 from ciso8601 import parse_rfc3339
 from geojson_pydantic import Feature
-from pydantic import (
-    AnyUrl,
-    ConfigDict,
-    Field,
-    field_serializer,
-    model_serializer,
-    model_validator,
-)
+from pydantic import AnyUrl, ConfigDict, Field, model_serializer, model_validator
 
 from stac_pydantic.links import Links
-from stac_pydantic.shared import (
-    DATETIME_RFC339,
-    SEMVER_REGEX,
-    Asset,
-    StacBaseModel,
-    StacCommonMetadata,
-)
+from stac_pydantic.shared import SEMVER_REGEX, Asset, StacBaseModel, StacCommonMetadata
 from stac_pydantic.version import STAC_VERSION
 
 
@@ -60,19 +46,25 @@ class Item(Feature, StacBaseModel):
     """
 
     id: str = Field(..., alias="id", min_length=1)
-    stac_version: str = Field(STAC_VERSION, pattern=SEMVER_REGEX)
+    stac_version: str = Field(..., pattern=SEMVER_REGEX)
     properties: ItemProperties
-    assets: Dict[str, Asset] = {}
-    links: Links = Links(root=[])
+    assets: Dict[str, Asset]
+    links: Links
     stac_extensions: Optional[List[AnyUrl]] = None
     collection: Optional[str] = None
 
     @model_validator(mode="before")
     @classmethod
-    def validate_bbox(cls, data: Any) -> Any:
+    def validate_defaults(cls, data: Any) -> Any:
         if isinstance(data, dict):
+            if data.get("stac_version") is None:
+                data["stac_version"] = STAC_VERSION
             if data.get("geometry") and data.get("bbox") is None:
                 raise ValueError("bbox is required if geometry is not null")
+            if data.get("assets") is None:
+                data["assets"] = {}
+            if data.get("links") is None:
+                data["links"] = []
         return data
 
     # https://github.com/developmentseed/geojson-pydantic/issues/147

--- a/stac_pydantic/item.py
+++ b/stac_pydantic/item.py
@@ -1,5 +1,5 @@
 from datetime import datetime as dt
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 from ciso8601 import parse_rfc3339
 from geojson_pydantic import Feature
@@ -26,40 +26,32 @@ from stac_pydantic.version import STAC_VERSION
 class ItemProperties(StacCommonMetadata):
     """
     https://github.com/radiantearth/stac-spec/blob/v1.0.0/item-spec/item-spec.md#properties-object
+    https://github.com/radiantearth/stac-spec/blob/v1.0.0/item-spec/item-spec.md#datetime
     """
-
-    datetime: Union[dt, str] = Field(..., alias="datetime")
 
     # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-config for more information.
     model_config = ConfigDict(extra="allow")
 
     @model_validator(mode="before")
     @classmethod
-    def validate_datetime(cls, data: Dict[str, Any]) -> Dict[str, Any]:
-        datetime = data.get("datetime")
-        start_datetime = data.get("start_datetime")
-        end_datetime = data.get("end_datetime")
+    def validate_datetime(cls, data: Any) -> Any:
+        if isinstance(data, dict):
 
-        if not datetime or datetime == "null":
-            if not start_datetime and not end_datetime:
-                raise ValueError(
-                    "start_datetime and end_datetime must be specified when datetime is null"
-                )
+            datetime = data.get("datetime")
+            start_datetime = data.get("start_datetime")
+            end_datetime = data.get("end_datetime")
 
-        if isinstance(datetime, str):
-            data["datetime"] = parse_rfc3339(datetime)
-
-        if isinstance(start_datetime, str):
-            data["start_datetime"] = parse_rfc3339(start_datetime)
-
-        if isinstance(end_datetime, str):
-            data["end_datetime"] = parse_rfc3339(end_datetime)
+            if datetime is None or datetime == "null":
+                if not start_datetime and not end_datetime:
+                    raise ValueError(
+                        "start_datetime and end_datetime must be specified when datetime is null"
+                    )
+                data["datetime"] = None
+            else:
+                if isinstance(datetime, str):
+                    data["datetime"] = parse_rfc3339(datetime)
 
         return data
-
-    @field_serializer("datetime")
-    def serialize_datetime(self, v: dt, _info: Any) -> str:
-        return v.strftime(DATETIME_RFC339)
 
 
 class Item(Feature, StacBaseModel):
@@ -70,18 +62,18 @@ class Item(Feature, StacBaseModel):
     id: str = Field(..., alias="id", min_length=1)
     stac_version: str = Field(STAC_VERSION, pattern=SEMVER_REGEX)
     properties: ItemProperties
-    assets: Dict[str, Asset]
-    links: Links
-    stac_extensions: Optional[List[AnyUrl]] = []
+    assets: Dict[str, Asset] = {}
+    links: Links = Links(root=[])
+    stac_extensions: Optional[List[AnyUrl]] = None
     collection: Optional[str] = None
 
     @model_validator(mode="before")
     @classmethod
-    def validate_bbox(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        if isinstance(values, dict):
-            if values.get("geometry") and values.get("bbox") is None:
+    def validate_bbox(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            if data.get("geometry") and data.get("bbox") is None:
                 raise ValueError("bbox is required if geometry is not null")
-        return values
+        return data
 
     # https://github.com/developmentseed/geojson-pydantic/issues/147
     @model_serializer(mode="wrap")

--- a/stac_pydantic/item.py
+++ b/stac_pydantic/item.py
@@ -1,6 +1,5 @@
 from typing import Any, Dict, List, Optional
 
-from ciso8601 import parse_rfc3339
 from geojson_pydantic import Feature
 from pydantic import AnyUrl, ConfigDict, Field, model_serializer, model_validator
 
@@ -33,9 +32,6 @@ class ItemProperties(StacCommonMetadata):
                         "start_datetime and end_datetime must be specified when datetime is null"
                     )
                 data["datetime"] = None
-            else:
-                if isinstance(datetime, str):
-                    data["datetime"] = parse_rfc3339(datetime)
 
         return data
 

--- a/stac_pydantic/shared.py
+++ b/stac_pydantic/shared.py
@@ -3,7 +3,7 @@ from enum import Enum, auto
 from typing import Any, Dict, List, Optional, Tuple, Union
 from warnings import warn
 
-from ciso8601 import parse_rfc3339
+import dateutil.parser
 from pydantic import BaseModel, ConfigDict, Field, field_serializer, model_validator
 
 from stac_pydantic.utils import AutoValueEnum
@@ -151,19 +151,19 @@ class StacCommonMetadata(StacBaseModel):
                 )
 
             if isinstance(datetime, str):
-                data["datetime"] = parse_rfc3339(datetime)
+                data["datetime"] = dateutil.parser.isoparse(datetime)
 
             if isinstance(start_datetime, str):
-                data["start_datetime"] = parse_rfc3339(start_datetime)
+                data["start_datetime"] = dateutil.parser.isoparse(start_datetime)
 
             if isinstance(end_datetime, str):
-                data["end_datetime"] = parse_rfc3339(end_datetime)
+                data["end_datetime"] = dateutil.parser.isoparse(end_datetime)
 
             if isinstance(created, str):
-                data["created"] = parse_rfc3339(created)
+                data["created"] = dateutil.parser.isoparse(created)
 
             if isinstance(updated, str):
-                data["updated"] = parse_rfc3339(updated)
+                data["updated"] = dateutil.parser.isoparse(updated)
 
         return data
 

--- a/tests/api/examples/v1.0.0/example-collection-list.json
+++ b/tests/api/examples/v1.0.0/example-collection-list.json
@@ -13,7 +13,8 @@
     ],
     "collections":[
        {
-          "id":"aster-l1t",
+         "type":"Collection",
+         "id":"aster-l1t",
           "description":"The [ASTER](https://terra.nasa.gov/about/terra-instruments/aster) instrument, launched on-board NASA's [Terra](https://terra.nasa.gov/) satellite in 1999, provides multispectral images of the Earth at 15m-90m resolution.  ASTER images provide information about land surface temperature, color, elevation, and mineral composition.\n\nThis dataset represents ASTER [L1T](https://lpdaac.usgs.gov/products/ast_l1tv003/) data from 2000-2006.  L1T images have been terrain-corrected and rotated to a north-up UTM projection.  Images are in [cloud-optimized GeoTIFF](https://www.cogeo.org/) format.\n",
           "stac_version":"1.0.0",
           "links":[
@@ -405,6 +406,7 @@
           }
        },
        {
+          "type":"Collection",
           "id":"landsat-8-c2-l2",
           "description":"The [Landsat](https://landsat.gsfc.nasa.gov/) program has been imaging the Earth since 1972; it provides a comprehensive, continuous archive of the Earth's surface.  [Landsat 8](https://www.usgs.gov/core-science-systems/nli/landsat/landsat-8) is the most recent satellite in the Landsat series.  Launched in 2013, Landsat 8 captures data in eleven spectral bands: ten optical/IR bands from the [Operational Land Imager](https://landsat.gsfc.nasa.gov/landsat-8/operational-land-imager) (OLI) instrument, and two thermal bands from the [Thermal Infrared Sensor](https://landsat.gsfc.nasa.gov/landsat-8/thermal-infrared-sensor-tirs) (TIRS) instrument.\n\nThis dataset represents the global archive of Level-2 Landsat 8 data from [Landsat Collection 2](https://www.usgs.gov/core-science-systems/nli/landsat/landsat-collection-2).  Because there is some latency before Level-2 data is available, a rolling window of recent Level-1 data is available as well.  Images are stored in [cloud-optimized GeoTIFF](https://www.cogeo.org/) format.\n",
           "stac_version":"1.0.0",
@@ -871,6 +873,7 @@
           }
        },
        {
+         "type":"Collection",
           "id":"sentinel-2-l2a",
           "description":"The [Sentinel-2](https://sentinel.esa.int/web/sentinel/missions/sentinel-2) program provides global imagery in thirteen spectral bands at 10m-60m resolution and a revisit time of approximately five days.  This dataset represents the global Sentinel-2 archive, from 2016 to the present, processed to L2A (bottom-of-atmosphere) using [Sen2Cor](https://step.esa.int/main/snap-supported-plugins/sen2cor/) and converted to [cloud-optimized GeoTIFF](https://www.cogeo.org/) format.",
           "stac_version":"1.0.0",
@@ -1496,7 +1499,8 @@
           }
        },
        {
-          "id":"naip",
+         "type":"Collection",
+         "id":"naip",
           "description":"The [National Agriculture Imagery Program](https://www.fsa.usda.gov/programs-and-services/aerial-photography/imagery-programs/naip-imagery/) (NAIP) provides US-wide, high-resolution aerial imagery, with four spectral bands (R, G, B, IR).  NAIP is administered by the [Aerial Field Photography Office](https://www.fsa.usda.gov/programs-and-services/aerial-photography/) (AFPO) within the [US Department of Agriculture](https://www.usda.gov/) (USDA).  Data are captured at least once every three years for each state.  This dataset represents NAIP data from 2010-present, in [cloud-optimized GeoTIFF](https://www.cogeo.org/) format.\n",
           "stac_version":"1.0.0",
           "links":[

--- a/tests/api/test_landing_page.py
+++ b/tests/api/test_landing_page.py
@@ -71,6 +71,7 @@ def test_schema(example_url, schema_url):
 
 def test_api_landing_page():
     LandingPage(
+        type="Catalog",
         id="test-landing-page",
         description="stac-api landing page",
         stac_extensions=[
@@ -100,6 +101,7 @@ def test_api_landing_page():
 
 def test_api_landing_page_is_catalog():
     landing_page = LandingPage(
+        type="Catalog",
         id="test-landing-page",
         description="stac-api landing page",
         stac_extensions=[

--- a/tests/api/test_search.py
+++ b/tests/api/test_search.py
@@ -1,5 +1,5 @@
 import time
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from pydantic import ValidationError
@@ -97,7 +97,10 @@ def test_invalid_temporal_search():
     t2 = t1 + timedelta(seconds=100)
     t3 = t2 + timedelta(seconds=100)
     with pytest.raises(ValidationError):
-        Search(collections=["collection1"], datetime=f"{t1.strftime(DATETIME_RFC339)}/{t2.strftime(DATETIME_RFC339)}/{t3.strftime(DATETIME_RFC339)}",)
+        Search(
+            collections=["collection1"],
+            datetime=f"{t1.strftime(DATETIME_RFC339)}/{t2.strftime(DATETIME_RFC339)}/{t3.strftime(DATETIME_RFC339)}",
+        )
 
     # End date is before start date
     start = datetime.utcnow()

--- a/tests/example_stac/example-collection-list.json
+++ b/tests/example_stac/example-collection-list.json
@@ -8,6 +8,7 @@
     ],
     "collections":[
        {
+         "type":"Collection",
           "id":"aster-l1t",
           "description":"The [ASTER](https://terra.nasa.gov/about/terra-instruments/aster) instrument, launched on-board NASA's [Terra](https://terra.nasa.gov/) satellite in 1999, provides multispectral images of the Earth at 15m-90m resolution.  ASTER images provide information about land surface temperature, color, elevation, and mineral composition.\n\nThis dataset represents ASTER [L1T](https://lpdaac.usgs.gov/products/ast_l1tv003/) data from 2000-2006.  L1T images have been terrain-corrected and rotated to a north-up UTM projection.  Images are in [cloud-optimized GeoTIFF](https://www.cogeo.org/) format.\n",
           "stac_version":"1.0.0",
@@ -400,7 +401,8 @@
           }
        },
        {
-          "id":"landsat-8-c2-l2",
+         "type":"Collection",
+         "id":"landsat-8-c2-l2",
           "description":"The [Landsat](https://landsat.gsfc.nasa.gov/) program has been imaging the Earth since 1972; it provides a comprehensive, continuous archive of the Earth's surface.  [Landsat 8](https://www.usgs.gov/core-science-systems/nli/landsat/landsat-8) is the most recent satellite in the Landsat series.  Launched in 2013, Landsat 8 captures data in eleven spectral bands: ten optical/IR bands from the [Operational Land Imager](https://landsat.gsfc.nasa.gov/landsat-8/operational-land-imager) (OLI) instrument, and two thermal bands from the [Thermal Infrared Sensor](https://landsat.gsfc.nasa.gov/landsat-8/thermal-infrared-sensor-tirs) (TIRS) instrument.\n\nThis dataset represents the global archive of Level-2 Landsat 8 data from [Landsat Collection 2](https://www.usgs.gov/core-science-systems/nli/landsat/landsat-collection-2).  Because there is some latency before Level-2 data is available, a rolling window of recent Level-1 data is available as well.  Images are stored in [cloud-optimized GeoTIFF](https://www.cogeo.org/) format.\n",
           "stac_version":"1.0.0",
           "links":[
@@ -866,7 +868,8 @@
           }
        },
        {
-          "id":"sentinel-2-l2a",
+         "type":"Collection",
+         "id":"sentinel-2-l2a",
           "description":"The [Sentinel-2](https://sentinel.esa.int/web/sentinel/missions/sentinel-2) program provides global imagery in thirteen spectral bands at 10m-60m resolution and a revisit time of approximately five days.  This dataset represents the global Sentinel-2 archive, from 2016 to the present, processed to L2A (bottom-of-atmosphere) using [Sen2Cor](https://step.esa.int/main/snap-supported-plugins/sen2cor/) and converted to [cloud-optimized GeoTIFF](https://www.cogeo.org/) format.",
           "stac_version":"1.0.0",
           "links":[
@@ -1491,7 +1494,8 @@
           }
        },
        {
-          "id":"naip",
+         "type":"Collection",
+         "id":"naip",
           "description":"The [National Agriculture Imagery Program](https://www.fsa.usda.gov/programs-and-services/aerial-photography/imagery-programs/naip-imagery/) (NAIP) provides US-wide, high-resolution aerial imagery, with four spectral bands (R, G, B, IR).  NAIP is administered by the [Aerial Field Photography Office](https://www.fsa.usda.gov/programs-and-services/aerial-photography/) (AFPO) within the [US Department of Agriculture](https://www.usda.gov/) (USDA).  Data are captured at least once every three years for each state.  This dataset represents NAIP data from 2010-present, in [cloud-optimized GeoTIFF](https://www.cogeo.org/) format.\n",
           "stac_version":"1.0.0",
           "links":[

--- a/tests/example_stac/example-collection_version-extension.json
+++ b/tests/example_stac/example-collection_version-extension.json
@@ -1,36 +1,51 @@
 {
-    "stac_version": "1.0.0",
-    "stac_extensions": ["https://stac-extensions.github.io/version/v1.0.0/schema.json"],
-    "id": "merraclim",
-    "title": "MERRAclim",
-    "description": "A high-resolution global dataset of remotely sensed bioclimatic variables for ecological modelling.",
-    "license": "CC0-1.0",
-    "version": "1",
-    "deprecated": true,
-    "extent": {
-      "spatial": {
-        "bbox": [[-180,-90,180,90]]
-      },
-      "temporal": {
-        "interval": [["1980-01-01T00:00:00Z","2009-12-31T23:59:59Z"]]
-      }
+  "type": "Collection",
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/version/v1.0.0/schema.json"
+  ],
+  "id": "merraclim",
+  "title": "MERRAclim",
+  "description": "A high-resolution global dataset of remotely sensed bioclimatic variables for ecological modelling.",
+  "license": "CC0-1.0",
+  "version": "1",
+  "deprecated": true,
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [
+          -180,
+          -90,
+          180,
+          90
+        ]
+      ]
     },
-    "links": [
-      {
-        "rel": "self",
-        "href": "https://datadryad.org/resource/doi:10.5061/dryad.s2v81/v1/collection.json"
-      },
-      {
-        "rel": "item",
-        "href": "https://datadryad.org/resource/doi:10.5061/dryad.s2v81/v1/item.json"
-      },
-      {
-        "rel": "root",
-        "href": "https://datadryad.org/resource/doi:10.5061/dryad.s2v81/catalog.json"
-      },
-      {
-        "rel": "latest-version",
-        "href": "https://datadryad.org/resource/doi:10.5061/dryad.s2v81/v2/collection.json"
-      }
-    ]
-  }
+    "temporal": {
+      "interval": [
+        [
+          "1980-01-01T00:00:00Z",
+          "2009-12-31T23:59:59Z"
+        ]
+      ]
+    }
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://datadryad.org/resource/doi:10.5061/dryad.s2v81/v1/collection.json"
+    },
+    {
+      "rel": "item",
+      "href": "https://datadryad.org/resource/doi:10.5061/dryad.s2v81/v1/item.json"
+    },
+    {
+      "rel": "root",
+      "href": "https://datadryad.org/resource/doi:10.5061/dryad.s2v81/catalog.json"
+    },
+    {
+      "rel": "latest-version",
+      "href": "https://datadryad.org/resource/doi:10.5061/dryad.s2v81/v2/collection.json"
+    }
+  ]
+}

--- a/tests/example_stac/example-landsat8_item-assets-extension.json
+++ b/tests/example_stac/example-landsat8_item-assets-extension.json
@@ -1,5 +1,6 @@
 {
-    "id": "landsat-8-l1",
+  "type": "Collection",
+  "id": "landsat-8-l1",
     "title": "Landsat 8 L1",
     "description": "Landat 8 imagery radiometrically calibrated and orthorectified using gound points and Digital Elevation Model (DEM) data to correct relief displacement.",
     "keywords": [

--- a/tests/example_stac/landsat-collection.json
+++ b/tests/example_stac/landsat-collection.json
@@ -1,5 +1,6 @@
 {
-    "stac_version": "1.0.0",
+  "type":"Collection",
+  "stac_version": "1.0.0",
     "stac_extensions": [],
     "id": "landsat-8-l1",
     "title": "Landsat 8 L1",

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,0 +1,22 @@
+from stac_pydantic.catalog import Catalog
+
+
+def test_catalog():
+    # Create a valid Catalog instance
+    catalog = Catalog(
+        type="Catalog",
+        id="my-catalog",
+        description="My STAC catalog",
+    )
+
+    catalog_json = catalog.model_dump(mode="json")
+
+    # Make default all values are set
+    assert catalog_json["id"] == "my-catalog"
+    assert catalog_json["description"] == "My STAC catalog"
+    assert catalog_json["stac_version"] == "1.0.0"
+    assert catalog_json["links"] == []
+    assert catalog_json["type"] == "Catalog"
+
+    assert "stac_extensions" not in catalog_json
+    assert "title" not in catalog_json

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -1,0 +1,124 @@
+import pytest
+from ciso8601 import parse_rfc3339
+from pydantic import ValidationError
+
+from stac_pydantic.item import Item
+
+
+def test_item():
+
+    item_data = {
+        "type": "Feature",
+        "id": "sample-item",
+        "stac_version": "1.0.0",
+        "geometry": {"type": "Point", "coordinates": [125.6, 10.1]},
+        "bbox": [125.6, 10.1, 125.6, 10.1],
+        "properties": {"datetime": "2022-01-01T00:00:00Z"},
+    }
+    item = Item(**item_data)
+
+    item_json = item.model_dump(mode="json")
+
+    # make sure that assets and links are set and parsed correctly
+    # datetime should be parsed as string and internally handled as datetime
+    # Collection and stac_extensions should not be parsed if not set
+    assert item_json["id"] == "sample-item"
+    assert item_json["stac_version"] == "1.0.0"
+    assert item_json["properties"]["datetime"] == "2022-01-01T00:00:00Z"
+    assert item.properties.datetime == parse_rfc3339("2022-01-01T00:00:00Z")
+    assert item_json["assets"] == {}
+    assert item_json["links"] == []
+
+    assert "collection" not in item_json
+    assert "stac_extensions" not in item_json
+
+
+def test_item_datetime_set_null():
+
+    item_data = {
+        "type": "Feature",
+        "id": "sample-item",
+        "stac_version": "1.0.0",
+        "geometry": {"type": "Point", "coordinates": [125.6, 10.1]},
+        "bbox": [125.6, 10.1, 125.6, 10.1],
+        "properties": {
+            "start_datetime": "2022-01-01T00:00:00Z",
+            "end_datetime": "2022-12-01T00:00:00Z",
+        },
+    }
+    item = Item(**item_data)
+
+    item_json = item.model_dump(mode="json")
+
+    # make sure datetime is parsed as null and start_datetime and end_datetime are parsed as strings
+    assert item_json["properties"]["datetime"] is None
+    assert item_json["properties"]["start_datetime"] == "2022-01-01T00:00:00Z"
+    assert item_json["properties"]["end_datetime"] == "2022-12-01T00:00:00Z"
+
+
+def test_item_bbox_missing():
+
+    item_data = {
+        "type": "Feature",
+        "id": "sample-item",
+        "stac_version": "1.0.0",
+        "geometry": {"type": "Point", "coordinates": [125.6, 10.1]},
+        "properties": {"datetime": "2022-01-01T00:00:00Z"},
+    }
+
+    with pytest.raises(ValidationError) as e:
+        Item(**item_data)
+        assert e.value.errors() == [
+            {
+                "loc": ("bbox",),
+                "msg": "bbox is required if geometry is not null",
+                "type": "value_error",
+            }
+        ]
+
+
+@pytest.mark.parametrize("property", ["start_datetime", "end_datetime"])
+def test_item_start_end_datetime_missing(property):
+
+    item_data = {
+        "type": "Feature",
+        "id": "sample-item",
+        "stac_version": "1.0.0",
+        "geometry": {"type": "Point", "coordinates": [125.6, 10.1]},
+        "bbox": [125.6, 10.1, 125.6, 10.1],
+        "properties": {
+            property: "2022-12-01T00:00:00Z",
+        },
+    }
+
+    with pytest.raises(ValidationError) as e:
+        Item(**item_data)
+        assert e.value.errors() == [
+            {
+                "loc": ("properties",),
+                "msg": "start_datetime and end_datetime must be specified when datetime is null",
+                "type": "value_error",
+            }
+        ]
+
+
+def test_item_datetime_missing():
+
+    item_data = {
+        "type": "Feature",
+        "id": "sample-item",
+        "stac_version": "1.0.0",
+        "geometry": {"type": "Point", "coordinates": [125.6, 10.1]},
+        "bbox": [125.6, 10.1, 125.6, 10.1],
+        "properties": {},
+    }
+
+    with pytest.raises(ValidationError) as e:
+        Item(**item_data)
+        assert e.value.errors() == [
+            {
+                "loc": ("properties",),
+                "msg": "start_datetime and end_datetime must be specified when datetime is null",
+                "type": "value_error",
+            }
+        ]

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -56,6 +56,27 @@ def test_item_datetime_set_null():
     assert item_json["properties"]["end_datetime"] == "2022-12-01T00:00:00Z"
 
 
+@pytest.mark.parametrize(
+    "datetime", ["2022-01-01T00:00:00", "2022-01-01", "2022-01", "2022"]
+)
+def test_item_datetime_no_z(datetime):
+
+    item_data = {
+        "type": "Feature",
+        "id": "sample-item",
+        "stac_version": "1.0.0",
+        "geometry": {"type": "Point", "coordinates": [125.6, 10.1]},
+        "bbox": [125.6, 10.1, 125.6, 10.1],
+        "properties": {"datetime": datetime},
+    }
+    item = Item(**item_data)
+
+    item_json = item.model_dump(mode="json")
+
+    # The model should fix the date and timezone for us
+    assert item_json["properties"]["datetime"] == "2022-01-01T00:00:00Z"
+
+
 def test_item_bbox_missing():
 
     item_data = {


### PR DESCRIPTION
- Require `type` property to be set for Catalog and Collections
- Fix validator for Item `datetime` and Common MetaData `start_datetime` and `end_datetime`
- Make sure all `datetime` fields are correctly parsed
- Include `datetime` and `license` to Common MetaData
- Make sure default values for required but unset fields are correctly parsed
- Add support from Python 3.12
- Lint all files
- Increase test coverage

