### PR TITLE
remove default for Types

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@
 - Rename `stac_pydantic.api.conformance.ConformanceClasses` to `stac_pydantic.api.conformance.Conformance`
 - Update pre-commit configuration and switch to astral-sh/ruff for linter and formater
 - Add official support for python 3.12
+- Enforce required `type` key for `Collection` and `Catalog` models
 
 3.0.0 (2024-01-25)
 ------------------

--- a/stac_pydantic/catalog.py
+++ b/stac_pydantic/catalog.py
@@ -23,4 +23,4 @@ class _Catalog(StacBaseModel):
 
 
 class Catalog(_Catalog):
-    type: Literal["Catalog"] = "Catalog"
+    type: Literal["Catalog"]

--- a/stac_pydantic/collection.py
+++ b/stac_pydantic/collection.py
@@ -52,4 +52,4 @@ class Collection(_Catalog):
     keywords: Optional[List[str]] = None
     providers: Optional[List[Provider]] = None
     summaries: Optional[Dict[str, Union[Range, List[Any], Dict[str, Any]]]] = None
-    type: Literal["Collection"] = "Collection"
+    type: Literal["Collection"]

--- a/tests/api/examples/v1.0.0/example-collection-list.json
+++ b/tests/api/examples/v1.0.0/example-collection-list.json
@@ -16,6 +16,7 @@
           "id":"aster-l1t",
           "description":"The [ASTER](https://terra.nasa.gov/about/terra-instruments/aster) instrument, launched on-board NASA's [Terra](https://terra.nasa.gov/) satellite in 1999, provides multispectral images of the Earth at 15m-90m resolution.  ASTER images provide information about land surface temperature, color, elevation, and mineral composition.\n\nThis dataset represents ASTER [L1T](https://lpdaac.usgs.gov/products/ast_l1tv003/) data from 2000-2006.  L1T images have been terrain-corrected and rotated to a north-up UTM projection.  Images are in [cloud-optimized GeoTIFF](https://www.cogeo.org/) format.\n",
           "stac_version":"1.0.0",
+          "type": "Collection",
           "links":[
              {
                 "href":"https://planetarycomputer.microsoft.com/api/stac/v1/collections/aster-l1t",
@@ -408,6 +409,7 @@
           "id":"landsat-8-c2-l2",
           "description":"The [Landsat](https://landsat.gsfc.nasa.gov/) program has been imaging the Earth since 1972; it provides a comprehensive, continuous archive of the Earth's surface.  [Landsat 8](https://www.usgs.gov/core-science-systems/nli/landsat/landsat-8) is the most recent satellite in the Landsat series.  Launched in 2013, Landsat 8 captures data in eleven spectral bands: ten optical/IR bands from the [Operational Land Imager](https://landsat.gsfc.nasa.gov/landsat-8/operational-land-imager) (OLI) instrument, and two thermal bands from the [Thermal Infrared Sensor](https://landsat.gsfc.nasa.gov/landsat-8/thermal-infrared-sensor-tirs) (TIRS) instrument.\n\nThis dataset represents the global archive of Level-2 Landsat 8 data from [Landsat Collection 2](https://www.usgs.gov/core-science-systems/nli/landsat/landsat-collection-2).  Because there is some latency before Level-2 data is available, a rolling window of recent Level-1 data is available as well.  Images are stored in [cloud-optimized GeoTIFF](https://www.cogeo.org/) format.\n",
           "stac_version":"1.0.0",
+          "type": "Collection",
           "links":[
              {
                 "href":"https://planetarycomputer.microsoft.com/api/stac/v1/collections/landsat-8-c2-l2",
@@ -874,6 +876,7 @@
           "id":"sentinel-2-l2a",
           "description":"The [Sentinel-2](https://sentinel.esa.int/web/sentinel/missions/sentinel-2) program provides global imagery in thirteen spectral bands at 10m-60m resolution and a revisit time of approximately five days.  This dataset represents the global Sentinel-2 archive, from 2016 to the present, processed to L2A (bottom-of-atmosphere) using [Sen2Cor](https://step.esa.int/main/snap-supported-plugins/sen2cor/) and converted to [cloud-optimized GeoTIFF](https://www.cogeo.org/) format.",
           "stac_version":"1.0.0",
+          "type": "Collection",
           "links":[
              {
                 "href":"https://planetarycomputer.microsoft.com/api/stac/v1/collections/sentinel-2-l2a",
@@ -1499,6 +1502,7 @@
           "id":"naip",
           "description":"The [National Agriculture Imagery Program](https://www.fsa.usda.gov/programs-and-services/aerial-photography/imagery-programs/naip-imagery/) (NAIP) provides US-wide, high-resolution aerial imagery, with four spectral bands (R, G, B, IR).  NAIP is administered by the [Aerial Field Photography Office](https://www.fsa.usda.gov/programs-and-services/aerial-photography/) (AFPO) within the [US Department of Agriculture](https://www.usda.gov/) (USDA).  Data are captured at least once every three years for each state.  This dataset represents NAIP data from 2010-present, in [cloud-optimized GeoTIFF](https://www.cogeo.org/) format.\n",
           "stac_version":"1.0.0",
+          "type": "Collection",
           "links":[
              {
                 "href":"https://planetarycomputer.microsoft.com/api/stac/v1/collections/naip",

--- a/tests/api/test_landing_page.py
+++ b/tests/api/test_landing_page.py
@@ -71,6 +71,7 @@ def test_schema(example_url, schema_url):
 
 def test_api_landing_page():
     LandingPage(
+        type="Catalog",
         id="test-landing-page",
         description="stac-api landing page",
         stac_extensions=[
@@ -100,6 +101,7 @@ def test_api_landing_page():
 
 def test_api_landing_page_is_catalog():
     landing_page = LandingPage(
+        type="Catalog",
         id="test-landing-page",
         description="stac-api landing page",
         stac_extensions=[

--- a/tests/example_stac/example-collection-list.json
+++ b/tests/example_stac/example-collection-list.json
@@ -11,6 +11,7 @@
           "id":"aster-l1t",
           "description":"The [ASTER](https://terra.nasa.gov/about/terra-instruments/aster) instrument, launched on-board NASA's [Terra](https://terra.nasa.gov/) satellite in 1999, provides multispectral images of the Earth at 15m-90m resolution.  ASTER images provide information about land surface temperature, color, elevation, and mineral composition.\n\nThis dataset represents ASTER [L1T](https://lpdaac.usgs.gov/products/ast_l1tv003/) data from 2000-2006.  L1T images have been terrain-corrected and rotated to a north-up UTM projection.  Images are in [cloud-optimized GeoTIFF](https://www.cogeo.org/) format.\n",
           "stac_version":"1.0.0",
+          "type": "Collection",
           "links":[
              {
                 "href":"https://planetarycomputer.microsoft.com/api/stac/v1/collections/aster-l1t",
@@ -403,6 +404,7 @@
           "id":"landsat-8-c2-l2",
           "description":"The [Landsat](https://landsat.gsfc.nasa.gov/) program has been imaging the Earth since 1972; it provides a comprehensive, continuous archive of the Earth's surface.  [Landsat 8](https://www.usgs.gov/core-science-systems/nli/landsat/landsat-8) is the most recent satellite in the Landsat series.  Launched in 2013, Landsat 8 captures data in eleven spectral bands: ten optical/IR bands from the [Operational Land Imager](https://landsat.gsfc.nasa.gov/landsat-8/operational-land-imager) (OLI) instrument, and two thermal bands from the [Thermal Infrared Sensor](https://landsat.gsfc.nasa.gov/landsat-8/thermal-infrared-sensor-tirs) (TIRS) instrument.\n\nThis dataset represents the global archive of Level-2 Landsat 8 data from [Landsat Collection 2](https://www.usgs.gov/core-science-systems/nli/landsat/landsat-collection-2).  Because there is some latency before Level-2 data is available, a rolling window of recent Level-1 data is available as well.  Images are stored in [cloud-optimized GeoTIFF](https://www.cogeo.org/) format.\n",
           "stac_version":"1.0.0",
+          "type": "Collection",
           "links":[
              {
                 "href":"https://planetarycomputer.microsoft.com/api/stac/v1/collections/landsat-8-c2-l2",
@@ -1494,6 +1496,7 @@
           "id":"naip",
           "description":"The [National Agriculture Imagery Program](https://www.fsa.usda.gov/programs-and-services/aerial-photography/imagery-programs/naip-imagery/) (NAIP) provides US-wide, high-resolution aerial imagery, with four spectral bands (R, G, B, IR).  NAIP is administered by the [Aerial Field Photography Office](https://www.fsa.usda.gov/programs-and-services/aerial-photography/) (AFPO) within the [US Department of Agriculture](https://www.usda.gov/) (USDA).  Data are captured at least once every three years for each state.  This dataset represents NAIP data from 2010-present, in [cloud-optimized GeoTIFF](https://www.cogeo.org/) format.\n",
           "stac_version":"1.0.0",
+          "type": "Collection",
           "links":[
              {
                 "href":"https://planetarycomputer.microsoft.com/api/stac/v1/collections/naip",

--- a/tests/example_stac/example-collection_version-extension.json
+++ b/tests/example_stac/example-collection_version-extension.json
@@ -1,6 +1,7 @@
 {
     "stac_version": "1.0.0",
     "stac_extensions": ["https://stac-extensions.github.io/version/v1.0.0/schema.json"],
+    "type": "Collection",
     "id": "merraclim",
     "title": "MERRAclim",
     "description": "A high-resolution global dataset of remotely sensed bioclimatic variables for ecological modelling.",

--- a/tests/example_stac/example-landsat8_item-assets-extension.json
+++ b/tests/example_stac/example-landsat8_item-assets-extension.json
@@ -1,6 +1,7 @@
 {
     "id": "landsat-8-l1",
     "title": "Landsat 8 L1",
+    "type": "Collection",
     "description": "Landat 8 imagery radiometrically calibrated and orthorectified using gound points and Digital Elevation Model (DEM) data to correct relief displacement.",
     "keywords": [
       "landsat",

--- a/tests/example_stac/landsat-collection.json
+++ b/tests/example_stac/landsat-collection.json
@@ -3,6 +3,7 @@
     "stac_extensions": [],
     "id": "landsat-8-l1",
     "title": "Landsat 8 L1",
+    "type": "Collection",
     "description": "Landat 8 imagery radiometrically calibrated and orthorectified using gound points and Digital Elevation Model (DEM) data to correct relief displacement.",
     "keywords": [
       "landsat"


### PR DESCRIPTION
closes https://github.com/stac-utils/stac-pydantic/issues/121

This PR removes the default values for `type` in the Catalog and Collection model (per specification) 