### PR TITLE
use StacBaseModel model instead of StacCommonMetadata

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@
 - Fix STAC API Query Extension operator names from ne->neq, le->lte, and ge->gte (#120, @philvarner)
 - Better **datetime** parsing/validation by using Pydantic native types and remove `ciso8601` requirement (#131, @eseglem)
 - move datetime validation in `StacCommonMetadata` model definition (#131, @eseglem)
+- use `StacBaseModel` as base model for `Asset` model (#148, @vincentsarago)
 
 3.0.0 (2024-01-25)
 ------------------

--- a/stac_pydantic/shared.py
+++ b/stac_pydantic/shared.py
@@ -171,7 +171,7 @@ class StacCommonMetadata(StacBaseModel):
         return self
 
 
-class Asset(StacCommonMetadata):
+class Asset(StacBaseModel):
     """
     https://github.com/radiantearth/stac-spec/blob/v1.0.0/item-spec/item-spec.md#asset-object
     """
@@ -185,10 +185,3 @@ class Asset(StacCommonMetadata):
     model_config = ConfigDict(
         populate_by_name=True, use_enum_values=True, extra="allow"
     )
-
-    @model_validator(mode="after")
-    def validate_datetime_or_start_end(self) -> Self:
-        # Overriding the parent method to avoid requiring datetime or start/end_datetime
-        # Additional fields MAY be added on the Asset object, but are not required.
-        # https://github.com/radiantearth/stac-spec/blob/v1.0.0/item-spec/item-spec.md#additional-fields-for-assets
-        return self


### PR DESCRIPTION
I don't really understand why the `Asset` model was based on `StacCommonMetadata` instead of `StacBaseModel`. 
