### PR TITLE
allow `null` datetime

### DIFF
--- a/stac_pydantic/item.py
+++ b/stac_pydantic/item.py
@@ -4,13 +4,7 @@ from geojson_pydantic import Feature
 from pydantic import AnyUrl, ConfigDict, Field, model_serializer, model_validator
 
 from stac_pydantic.links import Links
-from stac_pydantic.shared import (
-    SEMVER_REGEX,
-    Asset,
-    StacBaseModel,
-    StacCommonMetadata,
-    UtcDatetime,
-)
+from stac_pydantic.shared import SEMVER_REGEX, Asset, StacBaseModel, StacCommonMetadata
 from stac_pydantic.version import STAC_VERSION
 
 
@@ -19,10 +13,6 @@ class ItemProperties(StacCommonMetadata):
     https://github.com/radiantearth/stac-spec/blob/v1.0.0/item-spec/item-spec.md#properties-object
     """
 
-    # Overide the datetime field to be required
-    datetime: Optional[UtcDatetime] = Field(...)
-
-    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-config for more information.
     model_config = ConfigDict(extra="allow")
 
 

--- a/stac_pydantic/item.py
+++ b/stac_pydantic/item.py
@@ -20,7 +20,7 @@ class ItemProperties(StacCommonMetadata):
     """
 
     # Overide the datetime field to be required
-    datetime: Optional[UtcDatetime]
+    datetime: Optional[UtcDatetime] = Field(...)
 
     # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-config for more information.
     model_config = ConfigDict(extra="allow")

--- a/stac_pydantic/shared.py
+++ b/stac_pydantic/shared.py
@@ -134,7 +134,7 @@ class StacCommonMetadata(StacBaseModel):
     title: Optional[str] = None
     description: Optional[str] = None
     # Date and Time
-    datetime: Optional[UtcDatetime] = None
+    datetime: Optional[UtcDatetime] = Field(...)
     created: Optional[UtcDatetime] = None
     updated: Optional[UtcDatetime] = None
     # Date and Time Range

--- a/tests/example_stac/datetimerange.json
+++ b/tests/example_stac/datetimerange.json
@@ -37,7 +37,7 @@
       ]
     },
     "properties":{
-      "datetime":"2018-01-01T13:21:30Z",
+      "datetime":null,
       "start_datetime":"2018-01-01T13:21:30Z",
       "end_datetime":"2018-01-01T13:31:30Z"
     },

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -180,6 +180,16 @@ def test_stac_common_dates(args) -> None:
     StacCommonMetadata(**args)
 
 
+def test_stac_null_datetime_required() -> None:
+    with pytest.raises(ValidationError):
+        StacCommonMetadata(
+            **{
+                "start_datetime": "2024-01-01T00:00:00Z",
+                "end_datetime": "2024-01-02T00:00:00Z",
+            }
+        )
+
+
 @pytest.mark.parametrize(
     "args",
     [


### PR DESCRIPTION
overtake https://github.com/stac-utils/stac-pydantic/pull/116
closes https://github.com/stac-utils/stac-pydantic/issues/77


note: To me it seems that the specs says that `datetime` should be a `string` or `null` meaning that even if `null` it should be provided.

cc @alukach