### PR TITLE
add request and jsonschema optional dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Cache remote JSON schemas for extensions (#155, @avbentem)
+- add `requests` and `jsonschema` in a **validation** optional dependencies (#156, @vincentsarago)
 
 ## 3.1.0 (2024-05-21)
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ For more comprehensive schema validation and robust extension support, use [pyst
 
 ```shell
 python -m pip install stac-pydantic
+
+# or
+
+python -m pip install stac-pydantic["validation"]
 ```
 
 For local development:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
         "click>=8.1.7",
         "pydantic>=2.4.1",
         "geojson-pydantic>=1.0.0",
-        "requests",
 ]
 dynamic = ["version", "readme"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,12 @@ keywords=["stac", "pydantic", "validation"]
 authors=[{ name = "Arturo Engineering", email = "engineering@arturo.ai"}]
 license= { text = "MIT" }
 requires-python=">=3.8"
-dependencies = ["click>=8.1.7", "pydantic>=2.4.1", "geojson-pydantic>=1.0.0"]
+dependencies = [
+        "click>=8.1.7",
+        "pydantic>=2.4.1",
+        "geojson-pydantic>=1.0.0",
+        "requests",
+]
 dynamic = ["version", "readme"]
 
 [project.scripts]
@@ -31,6 +36,8 @@ homepage = "https://github.com/stac-utils/stac-pydantic"
 repository ="https://github.com/stac-utils/stac-pydantic.git"
 
 [project.optional-dependencies]
+validation = ["jsonschema>=4.19.1", "requests>=2.31.0"]
+
 dev = [
         "pytest>=7.4.2",
         "pytest-cov>=4.1.0",

--- a/stac_pydantic/scripts/cli.py
+++ b/stac_pydantic/scripts/cli.py
@@ -5,6 +5,16 @@ from pydantic import ValidationError
 from stac_pydantic.extensions import validate_extensions
 from stac_pydantic.item import Item
 
+try:
+    import requests
+except ImportError:  # pragma: nocover
+    requests = None  # type: ignore
+
+try:
+    import jsonschema
+except ImportError:  # pragma: nocover
+    jsonschema = None  # type: ignore
+
 
 @click.group(short_help="Validate STAC")
 def app() -> None:
@@ -16,14 +26,19 @@ def app() -> None:
 @click.argument("infile")
 def validate_item(infile: str) -> None:
     """Validate stac item"""
+    assert requests is not None, "requests must be installed to validate items"
+    assert jsonschema is not None, "jsonschema must be installed to validate items"
+
     r = requests.get(infile)
     r.raise_for_status()
+
     stac_item = r.json()
     try:
-        item = Item(**stac_item)
+        item = Item.model_validate(stac_item)
         validate_extensions(item, reraise_exception=True)
     except ValidationError as e:
         click.echo(str(e))
         return
+
     click.echo(f"{infile} is valid")
     return


### PR DESCRIPTION
Both `requests` and `jsonschema` are imported for validation but are not part of the dependencies. This PR adds a `validation` optional dependencies.
