### PR TITLE
add numberMatch and numberReturned in api.collections.Collections model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+
+## Unreleased
+
+- Add optional `numberMatched` and `numberReturned` to `api.collections.Collections` model to match the OGC Common part2 specification
+
 ## 3.1.2 (2024-08-20)
 
 - Add more **MimeTypes** (geojsonseq, pbf, mvt, ndjson, openapi_yaml, pdf, csv, parquet)

--- a/stac_pydantic/api/collections.py
+++ b/stac_pydantic/api/collections.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from pydantic import model_validator
 
@@ -16,6 +16,8 @@ class Collections(StacBaseModel):
 
     links: Links
     collections: List[Collection]
+    numberMatched: Optional[int] = None
+    numberReturned: Optional[int] = None
 
     @model_validator(mode="after")
     def required_links(self) -> "Collections":


### PR DESCRIPTION
ref https://docs.ogc.org/DRAFTS/20-024.html#_response

While the OGC Common part 2 is still a Draft, I'm pretty sure there is large chance of this to be adopted. It's also already used in pgstac and match the Items response  