### PR TITLE
fix: use AnyUrl for comparisons

### DIFF
--- a/stac_pydantic/api/landing.py
+++ b/stac_pydantic/api/landing.py
@@ -35,7 +35,7 @@ class LandingPage(Catalog):
             ), f"STAC API conform Landing pages must include a `{rel}` link."
 
         if (
-            HttpUrl(f"https://api.stacspec.org/v{STAC_API_VERSION}/collections")
+            AnyUrl(f"https://api.stacspec.org/v{STAC_API_VERSION}/collections")
             in self.conformsTo
         ):
             required_collections_rels = [Relations.data]


### PR DESCRIPTION
This worked as-was in pydantic v2.9 but not in v2.10. I discovered b/c tests were broken in **main** with **pydantic** v2.10.4:

```shell
$ uv pip install pydantic==2.10.4 
Resolved 4 packages in 9ms
Uninstalled 2 packages in 7ms
Installed 2 packages in 3ms
 - pydantic==2.9.2
 + pydantic==2.10.4
 - pydantic-core==2.23.4
 + pydantic-core==2.27.2
$ pytest -q
-- >8 ---
FAILED tests/api/test_landing_page.py::test_landing_page_invalid_features[landing_page_core.json] - Failed: DID NOT RAISE <class 'pydantic_core._pydantic_core.ValidationError'>
FAILED tests/api/test_landing_page.py::test_landing_page_invalid_features[landing_page_ogcapi-features.json] - Failed: DID NOT RAISE <class 'pydantic_core._pydantic_core.ValidationError'>
```