### PR TITLE
fix: validate search when datetime is none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 
 ## Unreleased
 
+- Fix `Search` validation when `datetime` is `None` (#165, @gadomski)
+
 ## 3.1.3 (2024-10-14)
 
 - Add optional `numberMatched` and `numberReturned` to `api.collections.Collections` model to match the OGC Common part2 specification
@@ -121,17 +123,14 @@
 - Add option to skip validation of remote extensions (#16)
 - Add helper function for item validation (#17)
 
-
 ## 1.0.3 (2020-06-03)
 
 - Bugfixes (#10)
 - Add rel types enum (#11)
 
-
 ## 1.0.2 (2020-06-02)
 
 - Add models for the STAC API spec (#7)
-
 
 ## 1.0.1 (2020-05-21)
 

--- a/stac_pydantic/api/search.py
+++ b/stac_pydantic/api/search.py
@@ -98,8 +98,10 @@ class Search(BaseModel):
 
     @field_validator("datetime")
     @classmethod
-    def validate_datetime(cls, value: str) -> str:
+    def validate_datetime(cls, value: Optional[str]) -> Optional[str]:
         # Split on "/" and replace no value or ".." with None
+        if value is None:
+            return value
         values = [v if v and v != ".." else None for v in value.split("/")]
 
         # If there are more than 2 dates, it's invalid

--- a/tests/api/test_search.py
+++ b/tests/api/test_search.py
@@ -149,3 +149,7 @@ def test_search_geometry_bbox():
 def test_search_invalid_bbox(bbox):
     with pytest.raises(ValidationError):
         Search(collections=["foo"], bbox=bbox)
+
+
+def test_search_none_datetime() -> None:
+    Search(datetime=None)


### PR DESCRIPTION
Search validation was broken if datetime was explicitly passed in as `None`.