### PR TITLE
fix bbox validation

### DIFF
--- a/stac_pydantic/api/search.py
+++ b/stac_pydantic/api/search.py
@@ -79,11 +79,14 @@ class Search(BaseModel):
                     raise ValueError(
                         "Maximum elevation must greater than minimum elevation"
                     )
+            # Validate against WGS84
+            if xmin < -180 or ymin < -90 or xmax > 180 or ymax > 90:
+                raise ValueError("Bounding box must be within (-180, -90, 180, 90)")
 
             if xmax < xmin:
                 # xmin > xmax is permitted when crossing the antimeridian
                 # https://datatracker.ietf.org/doc/html/rfc7946#section-5.2
-                if not ((xmin < 0) and (xmax > 0)):
+                if not ((xmax < 0) and (xmin > 0)):
                     raise ValueError(
                         "Maximum longitude must be greater than minimum longitude"
                     )
@@ -92,10 +95,6 @@ class Search(BaseModel):
                 raise ValueError(
                     "Maximum longitude must be greater than minimum longitude"
                 )
-
-            # Validate against WGS84
-            if xmin < -180 or ymin < -90 or xmax > 180 or ymax > 90:
-                raise ValueError("Bounding box must be within (-180, -90, 180, 90)")
 
         return v
 

--- a/stac_pydantic/api/search.py
+++ b/stac_pydantic/api/search.py
@@ -81,9 +81,12 @@ class Search(BaseModel):
                     )
 
             if xmax < xmin:
-                raise ValueError(
-                    "Maximum longitude must be greater than minimum longitude"
-                )
+                # xmin > xmax is permitted when crossing the antimeridian
+                # https://datatracker.ietf.org/doc/html/rfc7946#section-5.2
+                if not (xmin > 0 > xmax):
+                    raise ValueError(
+                        "Maximum longitude must be greater than minimum longitude"
+                    )
 
             if ymax < ymin:
                 raise ValueError(

--- a/stac_pydantic/api/search.py
+++ b/stac_pydantic/api/search.py
@@ -83,7 +83,7 @@ class Search(BaseModel):
             if xmax < xmin:
                 # xmin > xmax is permitted when crossing the antimeridian
                 # https://datatracker.ietf.org/doc/html/rfc7946#section-5.2
-                if not (xmin > 0 > xmax):
+                if not ((xmin < 0) and (xmax > 0)):
                     raise ValueError(
                         "Maximum longitude must be greater than minimum longitude"
                     )

--- a/stac_pydantic/api/search.py
+++ b/stac_pydantic/api/search.py
@@ -83,14 +83,6 @@ class Search(BaseModel):
             if xmin < -180 or ymin < -90 or xmax > 180 or ymax > 90:
                 raise ValueError("Bounding box must be within (-180, -90, 180, 90)")
 
-            if xmax < xmin:
-                # xmin > xmax is permitted when crossing the antimeridian
-                # https://datatracker.ietf.org/doc/html/rfc7946#section-5.2
-                if not ((xmax < 0) and (xmin > 0)):
-                    raise ValueError(
-                        "Maximum longitude must be greater than minimum longitude"
-                    )
-
             if ymax < ymin:
                 raise ValueError(
                     "Maximum longitude must be greater than minimum longitude"

--- a/tests/api/test_search.py
+++ b/tests/api/test_search.py
@@ -151,5 +151,20 @@ def test_search_invalid_bbox(bbox):
         Search(collections=["foo"], bbox=bbox)
 
 
+@pytest.mark.parametrize(
+    "bbox",
+    [
+        (
+            100.0,
+            0.0,
+            -95.0,
+            1.0,
+        ),  # xmin greater than xmax allowed when xmin > 0 and xmax < 0
+    ],
+)
+def test_search_valid_bbox(bbox):
+    Search(collections=["foo"], bbox=bbox)
+
+
 def test_search_none_datetime() -> None:
     Search(datetime=None)

--- a/tests/api/test_search.py
+++ b/tests/api/test_search.py
@@ -134,7 +134,6 @@ def test_search_geometry_bbox():
     "bbox",
     [
         (100.0, 1.0, 105.0, 0.0),  # ymin greater than ymax
-        (100.0, 0.0, 95.0, 1.0),  # xmin greater than xmax
         (100.0, 0.0, 5.0, 105.0, 1.0, 4.0),  # min elev greater than max elev
         (-200.0, 0.0, 105.0, 1.0),  # xmin is invalid WGS84
         (100.0, -100, 105.0, 1.0),  # ymin is invalid WGS84
@@ -149,21 +148,6 @@ def test_search_geometry_bbox():
 def test_search_invalid_bbox(bbox):
     with pytest.raises(ValidationError):
         Search(collections=["foo"], bbox=bbox)
-
-
-@pytest.mark.parametrize(
-    "bbox",
-    [
-        (
-            100.0,
-            0.0,
-            -95.0,
-            1.0,
-        ),  # xmin greater than xmax allowed when xmin > 0 and xmax < 0
-    ],
-)
-def test_search_valid_bbox(bbox):
-    Search(collections=["foo"], bbox=bbox)
 
 
 def test_search_none_datetime() -> None:


### PR DESCRIPTION
small fix to bbox validation allowing x_min (south west longitude) to be greater than x_max (north east longitude) when crossing the anti meridian as per https://datatracker.ietf.org/doc/html/rfc7946#section-5.2 

this issue was also reported in https://github.com/stac-utils/stac-pydantic/issues/122 and i am encountering the same validation error in https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch 
