### PR TITLE
fix(search): clear datetime between searches

### DIFF
--- a/tests/api/test_search.py
+++ b/tests/api/test_search.py
@@ -85,6 +85,10 @@ def test_temporal_search_two_tailed():
     assert search.start_date is None
     assert search.end_date == utcnow
 
+    search = Search(collections=["collection1"])
+    assert search.start_date is None
+    assert search.end_date is None
+
 
 def test_temporal_search_open():
     # Test open date range


### PR DESCRIPTION
Fixes https://github.com/stac-utils/stac-pydantic/issues/170

Clears `_start_date` and `_end_date` `Search` class variables between model instances.