### PR TITLE
fix Link 'label:assets' field type as list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 
 - Fix invalid `label:assets` type in `stac_pydantic.links.Link`.
   A single `str` was specified instead of `List[str]` as expected by the extension field
-  (see [Label Extension - Links](https://github.com/stac-extensions/label?tab=readme-ov-file#links-source-imagery)).
+  (see [Label Extension - Links](https://github.com/stac-extensions/label?tab=readme-ov-file#links-source-imagery)) (#183, @fmigneault).
+- Add validation of `Link` ensuring that `rel=source` is employed if `label:assets` is specified (#183, @fmigneault).
 
 ## 3.3.2 (2025-06-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 ## Unreleased
 
+- Fix invalid `label:assets` type in `stac_pydantic.links.Link`.
+  A single `str` was specified instead of `List[str]` as expected by the extension field
+  (see [Label Extension - Links](https://github.com/stac-extensions/label?tab=readme-ov-file#links-source-imagery)).
+
 ## 3.3.2 (2025-06-18)
 
 - Remove restriction on valid media types for links (#182, @mishaschwartz)

--- a/stac_pydantic/links.py
+++ b/stac_pydantic/links.py
@@ -19,7 +19,7 @@ class Link(StacBaseModel):
     title: Optional[str] = None
 
     # Label extension
-    label: Optional[str] = Field(default=None, alias="label:assets")
+    label: Optional[List[str]] = Field(default=None, alias="label:assets")
     model_config = ConfigDict(use_enum_values=True, extra="allow")
 
     def resolve(self, base_url: str) -> None:

--- a/tests/example_stac/roads_item.json
+++ b/tests/example_stac/roads_item.json
@@ -156,7 +156,9 @@
         "href": "roads_source.json",
         "rel": "source",
         "title": "The source imagery these road labels were derived from",
-        "label:assets": "road_labels"
+        "label:assets": [
+          "road_labels"
+        ]
       }
     ],
     "assets": {

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -105,6 +105,15 @@ def test_label_extension() -> None:
     dict_match(test_item, valid_item)
 
 
+def test_label_extension_rel_source() -> None:
+    with pytest.raises(ValidationError):
+        Link(href=LABEL_EXTENSION, rel="random", label_assets=["road_labels"])
+
+    link = Link(href=LABEL_EXTENSION, rel="source", label_assets=["road_labels"])
+    assert link.rel == "source"
+    assert link.label == ["road_labels"]
+
+
 def test_explicit_extension_validation() -> None:
     test_item = request(EO_EXTENSION)
 


### PR DESCRIPTION
Posting a STAC Item that contains `label:assets` as defined below results in a validation error since the `str` doesn't match the expected list (https://github.com/stac-extensions/label?tab=readme-ov-file#links-source-imagery).

```json
{
  "links": [
        {
          "rel": "source",
          "href": "https://hirondelle.crim.ca/data/stac/EuroSAT/data/full/ds/images/remote_sensing/otherDatasets/sentinel_2/tif/Pasture/Pasture_1687.tif",
          "type": "image/tiff; application=geotiff",
          "title": "Raster Pasture_1687 with Pasture class",
          "ml-aoi:role": "label",
          "label:assets": [
            "labels",
            "raster"
          ]
        }
  ]
}
```

I've tested that the fix works as expected by running our https://github.com/crim-ca/stac-app (STAC-FastAPI) with this `stac-pydantic` patch applied.
