### PR TITLE
remove 'label:assets' property from link

### DIFF
--- a/stac_pydantic/links.py
+++ b/stac_pydantic/links.py
@@ -18,8 +18,6 @@ class Link(StacBaseModel):
     type: Optional[Union[MimeTypes, str]] = None
     title: Optional[str] = None
 
-    # Label extension
-    label: Optional[str] = Field(default=None, alias="label:assets")
     model_config = ConfigDict(use_enum_values=True, extra="allow")
 
     def resolve(self, base_url: str) -> None:


### PR DESCRIPTION
Replaces #183, given suggestion https://github.com/stac-utils/stac-pydantic/pull/183#discussion_r2207470817

Goes along with https://github.com/stac-utils/stac-fastapi-pgstac/pull/269 to provide the correct (and any other extensions) validation.