### PR TITLE
Fix/remove invalid bbox check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 ## Unreleased
 
+## 3.5.2 (2026-05-29)
+
+- fix: remove wrong longitude check for antimeridian crossing bbox validation (#212, @vincentsarago)
+
 ## 3.5.1 (2026-05-05)
 
 - add top level public declaration `__all__`

--- a/stac_pydantic/shared.py
+++ b/stac_pydantic/shared.py
@@ -285,11 +285,6 @@ def validate_bbox(v: Optional[BBox]) -> Optional[BBox]:
         if xmin < -180 or ymin < -90 or xmax > 180 or ymax > 90:
             raise ValueError("Bounding box must be within (-180, -90, 180, 90)")
 
-        if xmax < xmin and (xmax > 0 or xmin < 0):
-            raise ValueError(
-                f"Maximum longitude ({xmax}) must be greater than minimum ({xmin}) longitude when not crossing the Antimeridian"
-            )
-
         if ymax < ymin:
             raise ValueError(
                 f"Maximum latitude ({ymax}) must be greater than minimum latitude  ({ymin})"

--- a/tests/api/test_search.py
+++ b/tests/api/test_search.py
@@ -150,12 +150,6 @@ def test_search_geometry_bbox():
         (100.0, 1.0, 105.0, 0.0),  # ymin greater than ymax
         (100.0, 0.0, 5.0, 105.0, 1.0, 4.0),  # min elev greater than max elev
         (-200.0, 0.0, 105.0, 1.0),  # xmin is invalid WGS84
-        (
-            105.0,
-            0.0,
-            100.0,
-            1.0,
-        ),  # xmin greater than xmax but not crossing Antimeridian
         (100.0, -100, 105.0, 1.0),  # ymin is invalid WGS84
         (100.0, 0.0, 190.0, 1.0),  # xmax is invalid WGS84
         (100.0, 0.0, 190.0, 100.0),  # ymax is invalid WGS84

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -462,10 +462,6 @@ def test_time_intervals_valid(interval) -> None:
     [
         # invalid Y order
         [[0, 1, 1, 0]],
-        # invalid X order (if crossing Antimeridian limit, xmin > 0)
-        [[-169, 0, -170, 1]],
-        # invalid X order (if crossing Antimeridian limit, xmax < 0)
-        [[170, 0, 169, 1]],
         # sub-sequent crossing Y
         [[0, 0, 2, 2], [0.5, 0.5, 2.0, 2.5]],
         # sub-sequent crossing X


### PR DESCRIPTION
closes #211 

A bbox crossing the dateline doesn't have to have its xmin < 0 or xmax > 0